### PR TITLE
Public models and first endpoint implementation

### DIFF
--- a/Example/AppStoreConnect-Swift-SDK/ViewController.swift
+++ b/Example/AppStoreConnect-Swift-SDK/ViewController.swift
@@ -7,17 +7,26 @@
 //
 
 import UIKit
+import AppStoreConnect_Swift_SDK
 
 final class ViewController: UIViewController {
 
+    /// Go to https://appstoreconnect.apple.com/access/api and create your own key. This is also the page to find the private key ID and the issuer ID.
+    /// Download the private key and open it in a text editor. Remove the enters and copy the contents over to the private key parameter.
+    private let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKey: "<YOUR PRIVATE KEY>")
+    lazy var provider: APIProvider = APIProvider(configuration: configuration)
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
-    }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+        provider.request(Endpoints.apps()) { (result) in
+            switch result {
+            case .success(let appsResponse):
+                print("Did fetch \(appsResponse.data.count) apps")
+            case .failure(let error):
+                print("Something went wrong fetching the apps: \(error)")
+            }
+        }
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -14,14 +14,58 @@ The Swift SDK to work with the App Store Connect API from Apple.
 - [x] APIProver with endpoints structure
 - [x] Add models for all endpoints
 - [x] JWT Logic to sign requests
+- [x] Get started section in the readme
 - [ ] TestFlight API implementation
-- [ ] Get started section in the readme
 - [ ] Users and Roles implementation
 - [ ] Sales and Finances implementation
 - [ ] Replace Alamofire dependency with own simple URLSession implementation
 
 ## Requesting API Access
 To request access, go to the new API Keys section in Users and Access in App Store Connect. Please note that you must be the Team Agent (Legal role) of a development team enrolled as an organization. Access for developers enrolled as an individual is coming soon.
+
+## How to use the SDK?
+*Not all endpoints are available yet, we're working hard to implement them all (see [Endpoints.swift](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/master/Sources/Endpoints.swift)).*
+
+#### 1. Import the framework:
+
+```swift
+import AppStoreConnect_Swift_SDK
+```
+
+#### 2. Create your API Configuration
+Go to [https://appstoreconnect.apple.com/access/api](https://appstoreconnect.apple.com/access/api) and create your own key. This is also the page to find your private key ID and the issuer ID.
+
+After downloading your private key, you can open the .p8 file containing the private key in a text editor which will show like the following content:
+
+```
+-----BEGIN PRIVATE KEY-----
+FDFDGgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwQgPaXyFvZfNydDEjxgjUCUxyGjXcQxiulEdGxoVbasV3GgCgYIKomokDj0DAQehRANCAAASffd/DU3TUWAoLmqE6hZL9A7i0DWpXtmIDCDiITRznC6K4/WjdIcuMcixy+m6O0IrffxJOablIX2VM8sHRpoiuy
+-----END PRIVATE KEY-----
+```
+
+Copy the contents and remove the whitelines, `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----`.
+
+Use this private key together with the issuer ID and the private key ID to create your configuration file:
+
+```swift
+let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKey: "<YOUR PRIVATE KEY>")
+```
+
+#### 3. Create an APIProvider and perform a request
+After creating an `APIProvider` instance with your `APIConfiguration` you can start performing your first request.
+
+```swift
+let provider: APIProvider = APIProvider(configuration: configuration)
+
+provider.request(Endpoints.apps()) { (result) in
+    switch result {
+    case .success(let appsResponse):
+        print("Did fetch \(appsResponse.data.count) apps")
+    case .failure(let error):
+        print("Something went wrong fetching the apps: \(error)")
+    }
+}
+```
 
 ## Installation
 

--- a/Sources/Endpoints.swift
+++ b/Sources/Endpoints.swift
@@ -29,3 +29,13 @@ public struct APIEndpoint<T: Decodable> {
         self.parameters = parameters
     }
 }
+
+/// Contains all API endpoints to the App Store Connect API
+public enum Endpoints {
+
+    /// Find and list apps added in App Store Connect.
+    public static func apps() -> APIEndpoint<AppsResponse> {
+        return APIEndpoint<AppsResponse>(path: "/v1/apps")
+    }
+
+}

--- a/Sources/Endpoints.swift
+++ b/Sources/Endpoints.swift
@@ -35,7 +35,7 @@ public enum Endpoints {
 
     /// Find and list apps added in App Store Connect.
     public static func apps() -> APIEndpoint<AppsResponse> {
-        return APIEndpoint<AppsResponse>(path: "/v1/apps")
+        return APIEndpoint<AppsResponse>(path: "apps")
     }
 
 }

--- a/Sources/Models/App.swift
+++ b/Sources/Models/App.swift
@@ -8,296 +8,296 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct App: Decodable {
+public struct App: Decodable {
 
     /// The resource's attributes.
-    let attributes: App.Attributes?
+    public let attributes: App.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: App.Relationships?
+    public let relationships: App.Relationships?
 
     /// (Required) The resource type.Value: apps
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// The bundle ID for your app. This ID must match the one you use in Xcode. The bundle ID cannot be changed after you upload your first build.
-        let bundleId: String?
+        public let bundleId: String?
     
         /// The name of your app as it will appear in the App Store. The maximum length is 30 characters.
-        let name: String?
+        public let name: String?
     
         /// The primary locale for your app. If localized app information isn’t available in an App Store territory, the information from your primary language is used instead.
-        let primaryLocale: String?
+        public let primaryLocale: String?
     
         /// A unique ID for your app that is not visible on the App Store.
-        let sku: String?
+        public let sku: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// App.Relationships.BetaLicenseAgreement
-        let betaLicenseAgreement: App.Relationships.BetaLicenseAgreement?
+        public let betaLicenseAgreement: App.Relationships.BetaLicenseAgreement?
     
         /// App.Relationships.PreReleaseVersions
-        let preReleaseVersions: App.Relationships.PreReleaseVersions?
+        public let preReleaseVersions: App.Relationships.PreReleaseVersions?
     
         /// App.Relationships.BetaAppLocalizations
-        let betaAppLocalizations: App.Relationships.BetaAppLocalizations?
+        public let betaAppLocalizations: App.Relationships.BetaAppLocalizations?
     
         /// App.Relationships.BetaGroups
-        let betaGroups: App.Relationships.BetaGroups?
+        public let betaGroups: App.Relationships.BetaGroups?
     
         /// App.Relationships.BetaTesters
-        let betaTesters: App.Relationships.BetaTesters?
+        public let betaTesters: App.Relationships.BetaTesters?
     
         /// App.Relationships.Builds
-        let builds: App.Relationships.Builds?
+        public let builds: App.Relationships.Builds?
     
         /// App.Relationships.BetaAppReviewDetail
-        let betaAppReviewDetail: App.Relationships.BetaAppReviewDetail?
+        public let betaAppReviewDetail: App.Relationships.BetaAppReviewDetail?
     }
 }
 
 /// MARK: App.Relationships
 extension App.Relationships {
     
-    struct BetaAppLocalizations: Decodable {
+    public struct BetaAppLocalizations: Decodable {
     
         /// [App.Relationships.BetaAppLocalizations.Data]
-        let data: [App.Relationships.BetaAppLocalizations.Data]?
+        public let data: [App.Relationships.BetaAppLocalizations.Data]?
     
         /// App.Relationships.BetaAppLocalizations.Links
-        let links: App.Relationships.BetaAppLocalizations.Links?
+        public let links: App.Relationships.BetaAppLocalizations.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct BetaAppReviewDetail: Decodable {
+    public struct BetaAppReviewDetail: Decodable {
     
         /// App.Relationships.BetaAppReviewDetail.Data
-        let data: App.Relationships.BetaAppReviewDetail.Data?
+        public let data: App.Relationships.BetaAppReviewDetail.Data?
     
         /// App.Relationships.BetaAppReviewDetail.Links
-        let links: App.Relationships.BetaAppReviewDetail.Links?
+        public let links: App.Relationships.BetaAppReviewDetail.Links?
     }
     
-    struct BetaGroups: Decodable {
+    public struct BetaGroups: Decodable {
     
         /// [App.Relationships.BetaGroups.Data]
-        let data: [App.Relationships.BetaGroups.Data]?
+        public let data: [App.Relationships.BetaGroups.Data]?
     
         /// App.Relationships.BetaGroups.Links
-        let links: App.Relationships.BetaGroups.Links?
+        public let links: App.Relationships.BetaGroups.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct BetaLicenseAgreement: Decodable {
+    public struct BetaLicenseAgreement: Decodable {
     
         /// App.Relationships.BetaLicenseAgreement.Data
-        let data: App.Relationships.BetaLicenseAgreement.Data?
+        public let data: App.Relationships.BetaLicenseAgreement.Data?
     
         /// App.Relationships.BetaLicenseAgreement.Links
-        let links: App.Relationships.BetaLicenseAgreement.Links?
+        public let links: App.Relationships.BetaLicenseAgreement.Links?
     }
     
-    struct BetaTesters: Decodable {
+    public struct BetaTesters: Decodable {
     
         /// [App.Relationships.BetaTesters.Data]
-        let data: [App.Relationships.BetaTesters.Data]?
+        public let data: [App.Relationships.BetaTesters.Data]?
     
         /// App.Relationships.BetaTesters.Links
-        let links: App.Relationships.BetaTesters.Links?
+        public let links: App.Relationships.BetaTesters.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct Builds: Decodable {
+    public struct Builds: Decodable {
     
         /// [App.Relationships.Builds.Data]
-        let data: [App.Relationships.Builds.Data]?
+        public let data: [App.Relationships.Builds.Data]?
     
         /// App.Relationships.Builds.Links
-        let links: App.Relationships.Builds.Links?
+        public let links: App.Relationships.Builds.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct PreReleaseVersions: Decodable {
+    public struct PreReleaseVersions: Decodable {
     
         /// [App.Relationships.PreReleaseVersions.Data]
-        let data: [App.Relationships.PreReleaseVersions.Data]?
+        public let data: [App.Relationships.PreReleaseVersions.Data]?
     
         /// App.Relationships.PreReleaseVersions.Links
-        let links: App.Relationships.PreReleaseVersions.Links?
+        public let links: App.Relationships.PreReleaseVersions.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
 }
 
 /// MARK: App.Relationships.BetaAppLocalizations
 extension App.Relationships.BetaAppLocalizations {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaAppLocalizations
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: App.Relationships.BetaAppReviewDetail
 extension App.Relationships.BetaAppReviewDetail {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaAppReviewDetails
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: App.Relationships.BetaGroups
 extension App.Relationships.BetaGroups {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaGroups
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: App.Relationships.BetaLicenseAgreement
 extension App.Relationships.BetaLicenseAgreement {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaLicenseAgreements
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: App.Relationships.BetaTesters
 extension App.Relationships.BetaTesters {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: App.Relationships.Builds
 extension App.Relationships.Builds {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: App.Relationships.PreReleaseVersions
 extension App.Relationships.PreReleaseVersions {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: preReleaseVersions
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/AppBetaAppLocalizationsLinkagesResponse.swift
+++ b/Sources/Models/AppBetaAppLocalizationsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct AppBetaAppLocalizationsLinkagesResponse: Decodable {
+public struct AppBetaAppLocalizationsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [AppBetaAppLocalizationsLinkagesResponse.Data]
+    public let data: [AppBetaAppLocalizationsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaAppLocalizations
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/AppBetaAppReviewDetailLinkageResponse.swift
+++ b/Sources/Models/AppBetaAppReviewDetailLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct AppBetaAppReviewDetailLinkageResponse: Decodable {
+public struct AppBetaAppReviewDetailLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: AppBetaAppReviewDetailLinkageResponse.Data
+    public let data: AppBetaAppReviewDetailLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaAppReviewDetails
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/AppBetaGroupsLinkagesResponse.swift
+++ b/Sources/Models/AppBetaGroupsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct AppBetaGroupsLinkagesResponse: Decodable {
+public struct AppBetaGroupsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [AppBetaGroupsLinkagesResponse.Data]
+    public let data: [AppBetaGroupsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaGroups
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/AppBetaLicenseAgreementLinkageResponse.swift
+++ b/Sources/Models/AppBetaLicenseAgreementLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct AppBetaLicenseAgreementLinkageResponse: Decodable {
+public struct AppBetaLicenseAgreementLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: AppBetaLicenseAgreementLinkageResponse.Data
+    public let data: AppBetaLicenseAgreementLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaLicenseAgreements
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/AppBetaTestersLinkagesRequest.swift
+++ b/Sources/Models/AppBetaTestersLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the IDs of related resources.
-struct AppBetaTestersLinkagesRequest: Decodable {
+public struct AppBetaTestersLinkagesRequest: Decodable {
 
     /// (Required) The types and IDs of related resources.
-    let data: [AppBetaTestersLinkagesRequest.Data]
+    public let data: [AppBetaTestersLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/AppBuildsLinkagesResponse.swift
+++ b/Sources/Models/AppBuildsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct AppBuildsLinkagesResponse: Decodable {
+public struct AppBuildsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [AppBuildsLinkagesResponse.Data]
+    public let data: [AppBuildsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/AppEncryptionDeclaration.swift
+++ b/Sources/Models/AppEncryptionDeclaration.swift
@@ -8,138 +8,138 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct AppEncryptionDeclaration: Decodable {
+public struct AppEncryptionDeclaration: Decodable {
 
     /// The resource's attributes.
-    let attributes: AppEncryptionDeclaration.Attributes?
+    public let attributes: AppEncryptionDeclaration.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: AppEncryptionDeclaration.Relationships?
+    public let relationships: AppEncryptionDeclaration.Relationships?
 
     /// (Required) The resource type.Value: appEncryptionDeclarations
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A Boolean value that indicates the intent to distribute your app on the French App Store.
-        let availableOnFrenchStore: Bool?
+        public let availableOnFrenchStore: Bool?
     
         /// A unique identifier that can be added to your app to associate it with a given declaration.
-        let codeValue: String?
+        public let codeValue: String?
     
         /// A Boolean value that indicates your app implements any proprietary encryption algorithms.
-        let containsProprietaryCryptography: Bool?
+        public let containsProprietaryCryptography: Bool?
     
         /// A Boolean value that indicates your app implements any standard encryption algorithms instead of, or in addition to, using or accessing the encryption in Apple’s operating systems.
-        let containsThirdPartyCryptography: Bool?
+        public let containsThirdPartyCryptography: Bool?
     
         /// The document name of your submitted export compliance documentation.
-        let documentName: String?
+        public let documentName: String?
     
         /// The file type of your submitted export compliance documentation.
-        let documentType: String?
+        public let documentType: String?
     
         /// The URL to the file of your submitted export compliance documentation.
-        let documentUrl: String?
+        public let documentUrl: String?
     
         /// A Boolean value that indicates your app is exempt based on your use of encryption and the app's availability.
-        let exempt: Bool?
+        public let exempt: Bool?
     
         /// The platform of the declaration.
-        let platform: Platform?
+        public let platform: Platform?
     
         /// A Boolean value that indicates whether your app uses, contains, or incorporates cryptography.
-        let usesEncryption: Bool?
+        public let usesEncryption: Bool?
     
         /// The approval state of your export compliance documentation.
-        let appEncryptionDeclarationState: AppEncryptionDeclarationState?
+        public let appEncryptionDeclarationState: AppEncryptionDeclarationState?
     
         /// The date and time you submitted your declaration.
-        let uploadedDate: Date?
+        public let uploadedDate: Date?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// AppEncryptionDeclaration.Relationships.App
-        let app: AppEncryptionDeclaration.Relationships.App?
+        public let app: AppEncryptionDeclaration.Relationships.App?
     
         /// AppEncryptionDeclaration.Relationships.Builds
-        let builds: AppEncryptionDeclaration.Relationships.Builds?
+        public let builds: AppEncryptionDeclaration.Relationships.Builds?
     }
 }
 
 /// MARK: AppEncryptionDeclaration.Relationships
 extension AppEncryptionDeclaration.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// AppEncryptionDeclaration.Relationships.App.Data
-        let data: AppEncryptionDeclaration.Relationships.App.Data?
+        public let data: AppEncryptionDeclaration.Relationships.App.Data?
     
         /// AppEncryptionDeclaration.Relationships.App.Links
-        let links: AppEncryptionDeclaration.Relationships.App.Links?
+        public let links: AppEncryptionDeclaration.Relationships.App.Links?
     }
     
-    struct Builds: Decodable {
+    public struct Builds: Decodable {
     
         /// [AppEncryptionDeclaration.Relationships.Builds.Data]
-        let data: [AppEncryptionDeclaration.Relationships.Builds.Data]?
+        public let data: [AppEncryptionDeclaration.Relationships.Builds.Data]?
     
         /// AppEncryptionDeclaration.Relationships.Builds.Links
-        let links: AppEncryptionDeclaration.Relationships.Builds.Links?
+        public let links: AppEncryptionDeclaration.Relationships.Builds.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
 }
 
 /// MARK: AppEncryptionDeclaration.Relationships.App
 extension AppEncryptionDeclaration.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: AppEncryptionDeclaration.Relationships.Builds
 extension AppEncryptionDeclaration.Relationships.Builds {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/AppEncryptionDeclarationAppLinkageResponse.swift
+++ b/Sources/Models/AppEncryptionDeclarationAppLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct AppEncryptionDeclarationAppLinkageResponse: Decodable {
+public struct AppEncryptionDeclarationAppLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: AppEncryptionDeclarationAppLinkageResponse.Data
+    public let data: AppEncryptionDeclarationAppLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/AppEncryptionDeclarationBuildsLinkagesRequest.swift
+++ b/Sources/Models/AppEncryptionDeclarationBuildsLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct AppEncryptionDeclarationBuildsLinkagesRequest: Decodable {
+public struct AppEncryptionDeclarationBuildsLinkagesRequest: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [AppEncryptionDeclarationBuildsLinkagesRequest.Data]
+    public let data: [AppEncryptionDeclarationBuildsLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/AppEncryptionDeclarationResponse.swift
+++ b/Sources/Models/AppEncryptionDeclarationResponse.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// A response containing a single resource.
-struct AppEncryptionDeclarationResponse: Decodable {
+public struct AppEncryptionDeclarationResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: AppEncryptionDeclaration
+    public let data: AppEncryptionDeclaration
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/AppEncryptionDeclarationState.swift
+++ b/Sources/Models/AppEncryptionDeclarationState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
     /// Strings representing the review or acceptance status of an app encryption declaration submitted to Apple.
-enum AppEncryptionDeclarationState: String, Decodable {
+public enum AppEncryptionDeclarationState: String, Decodable {
     case approved = "APPROVED"
     case invalid = "INVALID"
     case expired = "EXPIRED"

--- a/Sources/Models/AppEncryptionDeclarationsResponse.swift
+++ b/Sources/Models/AppEncryptionDeclarationsResponse.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct AppEncryptionDeclarationsResponse: Decodable {
+public struct AppEncryptionDeclarationsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [AppEncryptionDeclaration]
+    public let data: [AppEncryptionDeclaration]
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
 }

--- a/Sources/Models/AppPreReleaseVersionsLinkagesResponse.swift
+++ b/Sources/Models/AppPreReleaseVersionsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct AppPreReleaseVersionsLinkagesResponse: Decodable {
+public struct AppPreReleaseVersionsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [AppPreReleaseVersionsLinkagesResponse.Data]
+    public let data: [AppPreReleaseVersionsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: preReleaseVersions
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/AppResponse.swift
+++ b/Sources/Models/AppResponse.swift
@@ -8,19 +8,19 @@
 import Foundation
     
 /// A response containing a single resource.
-struct AppResponse: Decodable {
+public struct AppResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: App
+    public let data: App
 
     /// The requested relationship data.￼
     /// Possible types: BetaGroup, PrereleaseVersion, BetaAppLocalization, Build, BetaLicenseAgreement, BetaAppReviewDetail
-    let include: [AppResponse.Included]?
+    public let include: [AppResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case betaGroup(BetaGroup)
         case prereleaseVersion(PrereleaseVersion)
         case betaAppLocalization(BetaAppLocalization)
@@ -28,7 +28,7 @@ struct AppResponse: Decodable {
         case betaLicenseAgreement(BetaLicenseAgreement)
         case betaAppReviewDetail(BetaAppReviewDetail)
         
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let wrapped = try? BetaGroup(from: decoder) {
                 self = .betaGroup(wrapped)
                 return

--- a/Sources/Models/AppsResponse.swift
+++ b/Sources/Models/AppsResponse.swift
@@ -8,22 +8,22 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct AppsResponse: Decodable {
+public struct AppsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [App]
+    public let data: [App]
 
     /// The requested relationship data.￼
     ///  Possible types: BetaGroup, PrereleaseVersion, BetaAppLocalization, Build, BetaLicenseAgreement, BetaAppReviewDetail
-    let include: [AppsResponse.Included]?
+    public let include: [AppsResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case betaGroup(BetaGroup)
         case prereleaseVersion(PrereleaseVersion)
         case betaAppLocalization(BetaAppLocalization)
@@ -31,7 +31,7 @@ struct AppsResponse: Decodable {
         case betaLicenseAgreement(BetaLicenseAgreement)
         case betaAppReviewDetail(BetaAppReviewDetail)
 
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             
             if let wrapped = try? BetaGroup(from: decoder) {
                 self = .betaGroup(wrapped)

--- a/Sources/Models/BetaAppLocalization.swift
+++ b/Sources/Models/BetaAppLocalization.swift
@@ -8,83 +8,83 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BetaAppLocalization: Decodable {
+public struct BetaAppLocalization: Decodable {
 
     /// The resource's attributes.
-    let attributes: BetaAppLocalization.Attributes?
+    public let attributes: BetaAppLocalization.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: BetaAppLocalization.Relationships?
+    public let relationships: BetaAppLocalization.Relationships?
 
     /// (Required) The resource type.Value: betaAppLocalizations
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A description of your app that highlights features and functionality.
-        let description: String?
+        public let description: String?
     
         /// An email address to which beta testers can send feedback. Also appears as the reply-to address for TestFlight invitation emails.
-        let feedbackEmail: String?
+        public let feedbackEmail: String?
     
         /// The specified locale. Refer to Table 1 for possible values.
-        let locale: String?
+        public let locale: String?
     
         /// A URL with information about your app. This URL is visible to testers in the TestFlight app.
-        let marketingUrl: String?
+        public let marketingUrl: String?
     
         /// A URL that links to your company’s privacy policy. Privacy policies are recommended for all apps that collect user or device-related data or as otherwise required by law.
-        let privacyPolicyUrl: String?
+        public let privacyPolicyUrl: String?
     
         /// Your company’s privacy policy. Privacy policies are recommended for all apps that collect user or device-related data, or as otherwise required by law.
-        let tvOsPrivacyPolicy: String?
+        public let tvOsPrivacyPolicy: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaAppLocalization.Relationships.App
-        let app: BetaAppLocalization.Relationships.App?
+        public let app: BetaAppLocalization.Relationships.App?
     }
 }
 
 /// MARK: BetaAppLocalization.Relationships
 extension BetaAppLocalization.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// BetaAppLocalization.Relationships.App.Data
-        let data: BetaAppLocalization.Relationships.App.Data?
+        public let data: BetaAppLocalization.Relationships.App.Data?
     
         /// BetaAppLocalization.Relationships.App.Links
-        let links: BetaAppLocalization.Relationships.App.Links?
+        public let links: BetaAppLocalization.Relationships.App.Links?
     }
 }
 
 /// MARK: BetaAppLocalization.Relationships.App
 extension BetaAppLocalization.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/BetaAppLocalizationAppLinkageResponse.swift
+++ b/Sources/Models/BetaAppLocalizationAppLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BetaAppLocalizationAppLinkageResponse: Decodable {
+public struct BetaAppLocalizationAppLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BetaAppLocalizationAppLinkageResponse.Data
+    public let data: BetaAppLocalizationAppLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaAppLocalizationCreateRequest.swift
+++ b/Sources/Models/BetaAppLocalizationCreateRequest.swift
@@ -8,74 +8,74 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaAppLocalizationCreateRequest: Decodable {
+public struct BetaAppLocalizationCreateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaAppLocalizationCreateRequest.Data
+    public let data: BetaAppLocalizationCreateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The resource's attributes.
-        let attributes: BetaAppLocalizationCreateRequest.Data.Attributes
+        public let attributes: BetaAppLocalizationCreateRequest.Data.Attributes
     
         /// (Required) Navigational links to related data and included resource types and IDs.
-        let relationships: BetaAppLocalizationCreateRequest.Data.Relationships
+        public let relationships: BetaAppLocalizationCreateRequest.Data.Relationships
     
         /// (Required) The resource type.Value: betaAppLocalizations
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaAppLocalizationCreateRequest.Data
 extension BetaAppLocalizationCreateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A description of your app that highlights features and functionality.
-        let description: String?
+        public let description: String?
     
         /// An email address to which beta testers can send feedback. Also appears as the reply-to address for TestFlight invitation emails.
-        let feedbackEmail: String?
+        public let feedbackEmail: String?
     
         /// (Required) The specified locale. Refer to Table 1 for possible values.
-        let locale: String
+        public let locale: String
     
         /// A URL with information about your app. This URL is visible to testers in the TestFlight app.
-        let marketingUrl: String?
+        public let marketingUrl: String?
     
         /// A URL that links to your company’s privacy policy. Privacy policies are recommended for all apps that collect user or device-related data or as otherwise required by law.
-        let privacyPolicyUrl: String?
+        public let privacyPolicyUrl: String?
     
         /// Your company’s privacy policy. Privacy policies are recommended for all apps that collect user or device-related data, or as otherwise required by law.
-        let tvOsPrivacyPolicy: String?
+        public let tvOsPrivacyPolicy: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaAppLocalizationCreateRequest.Data.Relationships.App (Required)
-        let app: BetaAppLocalizationCreateRequest.Data.Relationships.App
+        public let app: BetaAppLocalizationCreateRequest.Data.Relationships.App
     }
 }
 
 /// MARK: BetaAppLocalizationCreateRequest.Data.Relationships
 extension BetaAppLocalizationCreateRequest.Data.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// BetaAppLocalizationCreateRequest.Data.Relationships.App.Data (Required)
-        let data: BetaAppLocalizationCreateRequest.Data.Relationships.App.Data
+        public let data: BetaAppLocalizationCreateRequest.Data.Relationships.App.Data
     }
 }
 
 /// MARK: BetaAppLocalizationCreateRequest.Data.Relationships.App
 extension BetaAppLocalizationCreateRequest.Data.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaAppLocalizationResponse.swift
+++ b/Sources/Models/BetaAppLocalizationResponse.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BetaAppLocalizationResponse: Decodable {
+public struct BetaAppLocalizationResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaAppLocalization
+    public let data: BetaAppLocalization
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/BetaAppLocalizationUpdateRequest.swift
+++ b/Sources/Models/BetaAppLocalizationUpdateRequest.swift
@@ -8,42 +8,42 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaAppLocalizationUpdateRequest: Decodable {
+public struct BetaAppLocalizationUpdateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaAppLocalizationUpdateRequest.Data
+    public let data: BetaAppLocalizationUpdateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// The resource's attributes.
-        let attributes: BetaAppLocalizationUpdateRequest.Data.Attributes?
+        public let attributes: BetaAppLocalizationUpdateRequest.Data.Attributes?
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaAppLocalizations
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaAppLocalizationUpdateRequest.Data
 extension BetaAppLocalizationUpdateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A description of your app that highlights features and functionality.
-        let description: String?
+        public let description: String?
     
         /// An email address to which beta testers can send feedback. Also appears as the reply-to address for TestFlight invitation emails.
-        let feedbackEmail: String?
+        public let feedbackEmail: String?
     
         /// A URL with information about your app. This URL is visible to testers in the TestFlight app
-        let marketingUrl: String?
+        public let marketingUrl: String?
     
         /// A URL that links to your company’s privacy policy. Privacy policies are recommended for all apps that collect user or device-related data or as otherwise required by law.
-        let privacyPolicyUrl: String?
+        public let privacyPolicyUrl: String?
     
         /// Your company’s privacy policy. Privacy policies are recommended for all apps that collect user or device-related data, or as otherwise required by law.
-        let tvOsPrivacyPolicy: String?
+        public let tvOsPrivacyPolicy: String?
     }
 }

--- a/Sources/Models/BetaAppLocalizationsResponse.swift
+++ b/Sources/Models/BetaAppLocalizationsResponse.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct BetaAppLocalizationsResponse: Decodable {
+public struct BetaAppLocalizationsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [BetaAppLocalization]
+    public let data: [BetaAppLocalization]
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
 }

--- a/Sources/Models/BetaAppReviewDetail.swift
+++ b/Sources/Models/BetaAppReviewDetail.swift
@@ -8,89 +8,89 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BetaAppReviewDetail: Decodable {
+public struct BetaAppReviewDetail: Decodable {
 
     /// The resource's attributes.
-    let attributes: BetaAppReviewDetail.Attributes?
+    public let attributes: BetaAppReviewDetail.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: BetaAppReviewDetail.Relationships?
+    public let relationships: BetaAppReviewDetail.Relationships?
 
     /// (Required) The resource type.Value: betaAppReviewDetails
-    let type: String
+    public let type: String
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// Email address of contact in case communication is needed with the beta app review.
-        let contactEmail: String?
+        public let contactEmail: String?
     
         /// First name of contact in case communication is needed with the beta app review.
-        let contactFirstName: String?
+        public let contactFirstName: String?
     
         /// Last name of contact in case communication is needed with the beta app review.
-        let contactLastName: String?
+        public let contactLastName: String?
     
         /// Phone number of contact in case communication is needed with the beta app review.
-        let contactPhone: String?
+        public let contactPhone: String?
     
         /// The user name to sign in to your app to review its features.
-        let demoAccountName: String?
+        public let demoAccountName: String?
     
         /// The password to sign in to your app to review its features.
-        let demoAccountPassword: String?
+        public let demoAccountPassword: String?
     
         /// A Boolean value that indicates if sign-in information is required to review all the features of your app. If users sign in using social media, provide information for an account for review. Credentials must be valid and active for duration of review.
-        let demoAccountRequired: Bool?
+        public let demoAccountRequired: Bool?
     
         /// Additional information about your app that can help during the review process. Do not include demo account details. Review notes have a maximum of 4,000 characters.
-        let notes: String?
+        public let notes: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaAppReviewDetail.Relationships.App
-        let app: BetaAppReviewDetail.Relationships.App?
+        public let app: BetaAppReviewDetail.Relationships.App?
     }
 }
 
 /// MARK: BetaAppReviewDetail.Relationships
 extension BetaAppReviewDetail.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// BetaAppReviewDetail.Relationships.App.Data
-        let data: BetaAppReviewDetail.Relationships.App.Data?
+        public let data: BetaAppReviewDetail.Relationships.App.Data?
     
         /// BetaAppReviewDetail.Relationships.App.Links
-        let links: BetaAppReviewDetail.Relationships.App.Links?
+        public let links: BetaAppReviewDetail.Relationships.App.Links?
     }
 }
 
 /// MARK: BetaAppReviewDetail.Relationships.App
 extension BetaAppReviewDetail.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/BetaAppReviewDetailAppLinkageResponse.swift
+++ b/Sources/Models/BetaAppReviewDetailAppLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BetaAppReviewDetailAppLinkageResponse: Decodable {
+public struct BetaAppReviewDetailAppLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BetaAppReviewDetailAppLinkageResponse.Data
+    public let data: BetaAppReviewDetailAppLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaAppReviewDetailResponse.swift
+++ b/Sources/Models/BetaAppReviewDetailResponse.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BetaAppReviewDetailResponse: Decodable {
+public struct BetaAppReviewDetailResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaAppReviewDetail
+    public let data: BetaAppReviewDetail
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/BetaAppReviewDetailUpdateRequest.swift
+++ b/Sources/Models/BetaAppReviewDetailUpdateRequest.swift
@@ -8,51 +8,51 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaAppReviewDetailUpdateRequest: Decodable {
+public struct BetaAppReviewDetailUpdateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaAppReviewDetailUpdateRequest.Data
+    public let data: BetaAppReviewDetailUpdateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// The resource's attributes.
-        let attributes: BetaAppReviewDetailUpdateRequest.Data.Attributes?
+        public let attributes: BetaAppReviewDetailUpdateRequest.Data.Attributes?
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaAppReviewDetails
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaAppReviewDetailUpdateRequest.Data
 extension BetaAppReviewDetailUpdateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// Email address of contact in case communication is needed with the beta app review.
-        let contactEmail: String?
+        public let contactEmail: String?
     
         /// First name of contact in case communication is needed with the beta app review.
-        let contactFirstName: String?
+        public let contactFirstName: String?
     
         /// Last name of contact in case communication is needed with the beta app review.
-        let contactLastName: String?
+        public let contactLastName: String?
     
         /// Phone number of contact in case communication is needed with the beta app review.
-        let contactPhone: String?
+        public let contactPhone: String?
     
         /// The user name to sign in to your app to review its features.
-        let demoAccountName: String?
+        public let demoAccountName: String?
     
         /// The password to sign in to your app to review its features.
-        let demoAccountPassword: String?
+        public let demoAccountPassword: String?
     
         /// A Boolean value that indicates if sign-in information is required to review all the features of your app. If users sign in using social media, provide information for an account for review. Credentials must be valid and active for duration of review.
-        let demoAccountRequired: Bool?
+        public let demoAccountRequired: Bool?
     
         /// Additional information about your app that can help during the review process. Do not include demo account details. Review notes have a maximum of 4,000 characters.
-        let notes: String?
+        public let notes: String?
     }
 }

--- a/Sources/Models/BetaAppReviewDetailsResponse.swift
+++ b/Sources/Models/BetaAppReviewDetailsResponse.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct BetaAppReviewDetailsResponse: Decodable {
+public struct BetaAppReviewDetailsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [BetaAppReviewDetail]
+    public let data: [BetaAppReviewDetail]
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
 }

--- a/Sources/Models/BetaAppReviewSubmission.swift
+++ b/Sources/Models/BetaAppReviewSubmission.swift
@@ -8,68 +8,68 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BetaAppReviewSubmission: Decodable {
+public struct BetaAppReviewSubmission: Decodable {
 
     /// The resource's attributes.
-    let attributes: BetaAppReviewSubmission.Attributes?
+    public let attributes: BetaAppReviewSubmission.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: BetaAppReviewSubmission.Relationships?
+    public let relationships: BetaAppReviewSubmission.Relationships?
 
     /// (Required) The resource type.Value: betaAppReviewSubmissions
-    let type: String
+    public let type: String
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A state that indicates the current status of the beta app review submission.
-        let betaReviewState: BetaReviewState?
+        public let betaReviewState: BetaReviewState?
     }
 
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaAppReviewSubmission.Relationships.Build
-        let build: BetaAppReviewSubmission.Relationships.Build?
+        public let build: BetaAppReviewSubmission.Relationships.Build?
     }
 }
 
 /// MARK: BetaAppReviewSubmission.Relationships
 extension BetaAppReviewSubmission.Relationships {
     
-    struct Build: Decodable {
+    public struct Build: Decodable {
     
         /// BetaAppReviewSubmission.Relationships.Build.Data
-        let data: BetaAppReviewSubmission.Relationships.Build.Data?
+        public let data: BetaAppReviewSubmission.Relationships.Build.Data?
     
         /// BetaAppReviewSubmission.Relationships.Build.Links
-        let links: BetaAppReviewSubmission.Relationships.Build.Links?
+        public let links: BetaAppReviewSubmission.Relationships.Build.Links?
     }
 }
 
 /// MARK: BetaAppReviewSubmission.Relationships.Build
 extension BetaAppReviewSubmission.Relationships.Build {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/BetaAppReviewSubmissionBuildLinkageResponse.swift
+++ b/Sources/Models/BetaAppReviewSubmissionBuildLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BetaAppReviewSubmissionBuildLinkageResponse: Decodable {
+public struct BetaAppReviewSubmissionBuildLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BetaAppReviewSubmissionBuildLinkageResponse.Data
+    public let data: BetaAppReviewSubmissionBuildLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaAppReviewSubmissionCreateRequest.swift
+++ b/Sources/Models/BetaAppReviewSubmissionCreateRequest.swift
@@ -8,50 +8,50 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaAppReviewSubmissionCreateRequest: Decodable {
+public struct BetaAppReviewSubmissionCreateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaAppReviewSubmissionCreateRequest.Data
+    public let data: BetaAppReviewSubmissionCreateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The types and IDs of the related data to update.
-        let relationships: BetaAppReviewSubmissionCreateRequest.Data.Relationships
+        public let relationships: BetaAppReviewSubmissionCreateRequest.Data.Relationships
     
         /// (Required) The resource type.Value: betaAppReviewSubmissions
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaAppReviewSubmissionCreateRequest.Data
 extension BetaAppReviewSubmissionCreateRequest.Data {
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaAppReviewSubmissionCreateRequest.Data.Relationships.Build (Required)
-        let build: BetaAppReviewSubmissionCreateRequest.Data.Relationships.Build
+        public let build: BetaAppReviewSubmissionCreateRequest.Data.Relationships.Build
     }
 }
 
 /// MARK: BetaAppReviewSubmissionCreateRequest.Data.Relationships
 extension BetaAppReviewSubmissionCreateRequest.Data.Relationships {
     
-    struct Build: Decodable {
+    public struct Build: Decodable {
     
         /// BetaAppReviewSubmissionCreateRequest.Data.Relationships.Build.Data (Required)
-        let data: BetaAppReviewSubmissionCreateRequest.Data.Relationships.Build.Data
+        public let data: BetaAppReviewSubmissionCreateRequest.Data.Relationships.Build.Data
     }
 }
 
 /// MARK: BetaAppReviewSubmissionCreateRequest.Data.Relationships.Build
 extension BetaAppReviewSubmissionCreateRequest.Data.Relationships.Build {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaAppReviewSubmissionResponse.swift
+++ b/Sources/Models/BetaAppReviewSubmissionResponse.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BetaAppReviewSubmissionResponse: Decodable {
+public struct BetaAppReviewSubmissionResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaAppReviewSubmission
+    public let data: BetaAppReviewSubmission
 
     /// The requested relationship data.
-    let include: [Build]?
+    public let include: [Build]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/BetaAppReviewSubmissionsResponse.swift
+++ b/Sources/Models/BetaAppReviewSubmissionsResponse.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct BetaAppReviewSubmissionsResponse: Decodable {
+public struct BetaAppReviewSubmissionsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [BetaAppReviewSubmission]
+    public let data: [BetaAppReviewSubmission]
 
     /// The requested relationship data.
-    let include: [Build]?
+    public let include: [Build]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
 }

--- a/Sources/Models/BetaBuildLocalization.swift
+++ b/Sources/Models/BetaBuildLocalization.swift
@@ -8,71 +8,71 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BetaBuildLocalization: Decodable {
+public struct BetaBuildLocalization: Decodable {
 
     /// The resource's attributes.
-    let attributes: BetaBuildLocalization.Attributes?
+    public let attributes: BetaBuildLocalization.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: BetaBuildLocalization.Relationships?
+    public let relationships: BetaBuildLocalization.Relationships?
 
     /// (Required) The resource type.Value: betaBuildLocalizations
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// The specified locale. Refer to Table 1 for possible values.
-        let locale: String?
+        public let locale: String?
     
         /// A field that describes changes and additions to a build and indicates features you would like your users to test.
-        let whatsNew: String?
+        public let whatsNew: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaBuildLocalization.Relationships.Build
-        let build: BetaBuildLocalization.Relationships.Build?
+        public let build: BetaBuildLocalization.Relationships.Build?
     }
 }
 
 /// MARK: BetaBuildLocalization.Relationships
 extension BetaBuildLocalization.Relationships {
     
-    struct Build: Decodable {
+    public struct Build: Decodable {
     
         /// BetaBuildLocalization.Relationships.Build.Data
-        let data: BetaBuildLocalization.Relationships.Build.Data?
+        public let data: BetaBuildLocalization.Relationships.Build.Data?
     
         /// BetaBuildLocalization.Relationships.Build.Links
-        let links: BetaBuildLocalization.Relationships.Build.Links?
+        public let links: BetaBuildLocalization.Relationships.Build.Links?
     }
 }
 
 /// MARK: BetaBuildLocalization.Relationships.Build
 extension BetaBuildLocalization.Relationships.Build {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/BetaBuildLocalizationBuildLinkageResponse.swift
+++ b/Sources/Models/BetaBuildLocalizationBuildLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BetaBuildLocalizationBuildLinkageResponse: Decodable {
+public struct BetaBuildLocalizationBuildLinkageResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaBuildLocalizationBuildLinkageResponse.Data
+    public let data: BetaBuildLocalizationBuildLinkageResponse.Data
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaBuildLocalizationCreateRequest.swift
+++ b/Sources/Models/BetaBuildLocalizationCreateRequest.swift
@@ -8,62 +8,62 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaBuildLocalizationCreateRequest: Decodable {
+public struct BetaBuildLocalizationCreateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaBuildLocalizationCreateRequest.Data
+    public let data: BetaBuildLocalizationCreateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The resource's attributes.
-        let attributes: BetaBuildLocalizationCreateRequest.Data.Attributes
+        public let attributes: BetaBuildLocalizationCreateRequest.Data.Attributes
     
         /// (Required) Navigational links to related data and included resource types and IDs.
-        let relationships: BetaBuildLocalizationCreateRequest.Data.Relationships
+        public let relationships: BetaBuildLocalizationCreateRequest.Data.Relationships
     
         /// (Required) The resource type.Value: betaBuildLocalizations
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaBuildLocalizationCreateRequest.Data
 extension BetaBuildLocalizationCreateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// (Required) The specified locale. Refer to Table 1 for possible values.
-        let locale: String
+        public let locale: String
     
         /// A field that describes changes and additions to a build and indicates features you would like your users to test.
-        let whatsNew: String?
+        public let whatsNew: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaBuildLocalizationCreateRequest.Data.Relationships.Build (Required)
-        let build: BetaBuildLocalizationCreateRequest.Data.Relationships.Build
+        public let build: BetaBuildLocalizationCreateRequest.Data.Relationships.Build
     }
 }
 
 /// MARK: BetaBuildLocalizationCreateRequest.Data.Relationships
 extension BetaBuildLocalizationCreateRequest.Data.Relationships {
     
-    struct Build: Decodable {
+    public struct Build: Decodable {
     
         /// BetaBuildLocalizationCreateRequest.Data.Relationships.Build.Data (Required)
-        let data: BetaBuildLocalizationCreateRequest.Data.Relationships.Build.Data
+        public let data: BetaBuildLocalizationCreateRequest.Data.Relationships.Build.Data
     }
 }
 
 /// MARK: BetaBuildLocalizationCreateRequest.Data.Relationships.Build
 extension BetaBuildLocalizationCreateRequest.Data.Relationships.Build {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaBuildLocalizationResponse.swift
+++ b/Sources/Models/BetaBuildLocalizationResponse.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BetaBuildLocalizationResponse: Decodable {
+public struct BetaBuildLocalizationResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaBuildLocalization
+    public let data: BetaBuildLocalization
 
     /// The requested relationship data.
-    let include: [Build]?
+    public let include: [Build]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/BetaBuildLocalizationUpdateRequest.swift
+++ b/Sources/Models/BetaBuildLocalizationUpdateRequest.swift
@@ -8,30 +8,30 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaBuildLocalizationUpdateRequest: Decodable {
+public struct BetaBuildLocalizationUpdateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaBuildLocalizationUpdateRequest.Data
+    public let data: BetaBuildLocalizationUpdateRequest.Data
 
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// The resource's attributes.
-        let attributes: BetaBuildLocalizationUpdateRequest.Data.Attributes?
+        public let attributes: BetaBuildLocalizationUpdateRequest.Data.Attributes?
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaBuildLocalizations
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaBuildLocalizationUpdateRequest.Data
 extension BetaBuildLocalizationUpdateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A field that describes changes and additions to a build and indicates features you would like your users to test.
-        let whatsNew: String?
+        public let whatsNew: String?
     }
 }

--- a/Sources/Models/BetaBuildLocalizationsResponse.swift
+++ b/Sources/Models/BetaBuildLocalizationsResponse.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct BetaBuildLocalizationsResponse: Decodable {
+public struct BetaBuildLocalizationsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [BetaBuildLocalization]
+    public let data: [BetaBuildLocalization]
 
     /// The requested relationship data.
-    let include: [Build]?
+    public let include: [Build]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
 }

--- a/Sources/Models/BetaGroup.swift
+++ b/Sources/Models/BetaGroup.swift
@@ -8,163 +8,163 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BetaGroup: Decodable {
+public struct BetaGroup: Decodable {
 
     /// The resource's attributes.
-    let attributes: BetaGroup.Attributes?
+    public let attributes: BetaGroup.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: BetaGroup.Relationships?
+    public let relationships: BetaGroup.Relationships?
 
     /// (Required) The resource type.Value: betaGroups
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A Boolean value that indicates whether the group is internal. Only existing users of App Store Connect may be added for internal beta testing.
-        let isInternalGroup: Bool?
+        public let isInternalGroup: Bool?
     
         /// The name for the beta group.
-        let name: String?
+        public let name: String?
     
         /// The URL of the public link provided to your app's beta testers.
-        let publicLink: String?
+        public let publicLink: String?
     
         /// A Boolean value that indicates whether a public link is enabled. Enabling a link allows you to invite anyone outside of your team to beta test your app. When you share this link, testers will be able to install the beta version of your app on their devices in TestFlight and share the link with others.
-        let publicLinkEnabled: Bool?
+        public let publicLinkEnabled: Bool?
     
         /// The ID as part of the URL of the public link.
-        let publicLinkId: String?
+        public let publicLinkId: String?
     
         /// The maximum number of testers that can join this beta group using the public link. Values must be between 1 and 10,000.
-        let publicLinkLimit: Int?
+        public let publicLinkLimit: Int?
     
         /// A Boolean value that limits the number of testers who can join the beta group using the public link.
-        let publicLinkLimitEnabled: Bool?
+        public let publicLinkLimitEnabled: Bool?
     
         /// The creation date of the beta group.
-        let createdDate: Date?
+        public let createdDate: Date?
     }
 
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaGroup.Relationships.App
-        let app: BetaGroup.Relationships.App?
+        public let app: BetaGroup.Relationships.App?
     
         /// BetaGroup.Relationships.BetaTesters
-        let betaTesters: BetaGroup.Relationships.BetaTesters?
+        public let betaTesters: BetaGroup.Relationships.BetaTesters?
     
         /// BetaGroup.Relationships.Builds
-        let builds: BetaGroup.Relationships.Builds?
+        public let builds: BetaGroup.Relationships.Builds?
     }
 }
 
 /// MARK: BetaGroup.Relationships
 extension BetaGroup.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// BetaGroup.Relationships.App.Data
-        let data: BetaGroup.Relationships.App.Data?
+        public let data: BetaGroup.Relationships.App.Data?
     
         /// BetaGroup.Relationships.App.Links
-        let links: BetaGroup.Relationships.App.Links?
+        public let links: BetaGroup.Relationships.App.Links?
     }
     
-    struct BetaTesters: Decodable {
+    public struct BetaTesters: Decodable {
     
         /// [BetaGroup.Relationships.BetaTesters.Data]
-        let data: [BetaGroup.Relationships.BetaTesters.Data]?
+        public let data: [BetaGroup.Relationships.BetaTesters.Data]?
     
         /// BetaGroup.Relationships.BetaTesters.Links
-        let links: BetaGroup.Relationships.BetaTesters.Links?
+        public let links: BetaGroup.Relationships.BetaTesters.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct Builds: Decodable {
+    public struct Builds: Decodable {
     
         /// [BetaGroup.Relationships.Builds.Data]
-        let data: [BetaGroup.Relationships.Builds.Data]?
+        public let data: [BetaGroup.Relationships.Builds.Data]?
     
         /// BetaGroup.Relationships.Builds.Links
-        let links: BetaGroup.Relationships.Builds.Links?
+        public let links: BetaGroup.Relationships.Builds.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
 }
 
 /// MARK: BetaGroup.Relationships.App
 extension BetaGroup.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: BetaGroup.Relationships.BetaTesters
 extension BetaGroup.Relationships.BetaTesters {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: BetaGroup.Relationships.Builds
 extension BetaGroup.Relationships.Builds {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/BetaGroupAppLinkageResponse.swift
+++ b/Sources/Models/BetaGroupAppLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BetaGroupAppLinkageResponse: Decodable {
+public struct BetaGroupAppLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BetaGroupAppLinkageResponse.Data
+    public let data: BetaGroupAppLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaGroupBetaTestersLinkagesRequest.swift
+++ b/Sources/Models/BetaGroupBetaTestersLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the IDs of related resources.
-struct BetaGroupBetaTestersLinkagesRequest: Decodable {
+public struct BetaGroupBetaTestersLinkagesRequest: Decodable {
 
     /// (Required) The types and IDs of related resources.
-    let data: [BetaGroupBetaTestersLinkagesRequest.Data]
+    public let data: [BetaGroupBetaTestersLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaGroupBetaTestersLinkagesResponse.swift
+++ b/Sources/Models/BetaGroupBetaTestersLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct BetaGroupBetaTestersLinkagesResponse: Decodable {
+public struct BetaGroupBetaTestersLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [BetaGroupBetaTestersLinkagesResponse.Data]
+    public let data: [BetaGroupBetaTestersLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaGroupBuildsLinkagesRequest.swift
+++ b/Sources/Models/BetaGroupBuildsLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the IDs of related resources.
-struct BetaGroupBuildsLinkagesRequest: Decodable {
+public struct BetaGroupBuildsLinkagesRequest: Decodable {
 
     /// (Required) The types and IDs of related resources.
-    let data: [BetaGroupBuildsLinkagesRequest.Data]
+    public let data: [BetaGroupBuildsLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaGroupBuildsLinkagesResponse.swift
+++ b/Sources/Models/BetaGroupBuildsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct BetaGroupBuildsLinkagesResponse: Decodable {
+public struct BetaGroupBuildsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [BetaGroupBuildsLinkagesResponse.Data]
+    public let data: [BetaGroupBuildsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaGroupCreateRequest.swift
+++ b/Sources/Models/BetaGroupCreateRequest.swift
@@ -8,112 +8,112 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaGroupCreateRequest: Decodable {
+public struct BetaGroupCreateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaGroupCreateRequest.Data
+    public let data: BetaGroupCreateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The resource's attributes.
-        let attributes: BetaGroupCreateRequest.Data.Attributes
+        public let attributes: BetaGroupCreateRequest.Data.Attributes
     
         /// (Required) Navigational links to related data and included resource types and IDs.
-        let relationships: BetaGroupCreateRequest.Data.Relationships
+        public let relationships: BetaGroupCreateRequest.Data.Relationships
     
         /// (Required) The resource type.Value: betaGroups
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaGroupCreateRequest.Data
 extension BetaGroupCreateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// (Required) The name for the beta group.
-        let name: String
+        public let name: String
     
         /// A Boolean value that indicates whether a public link is enabled. Enabling a link allows you to invite anyone outside of your team to beta test your app. When you share this link, testers will be able to install the beta version of your app on their devices in TestFlight and share the link with others.
-        let publicLinkEnabled: Bool?
+        public let publicLinkEnabled: Bool?
     
         /// The maximum number of testers that can join this beta group using the public link. Values must be between 1 and 10,000.
-        let publicLinkLimit: Int?
+        public let publicLinkLimit: Int?
     
         /// A Boolean value that limits the number of testers who can join the beta group using the public link.
-        let publicLinkLimitEnabled: Bool?
+        public let publicLinkLimitEnabled: Bool?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaGroupCreateRequest.Data.Relationships.App (Required)
-        let app: BetaGroupCreateRequest.Data.Relationships.App
+        public let app: BetaGroupCreateRequest.Data.Relationships.App
     
         /// BetaGroupCreateRequest.Data.Relationships.BetaTesters
-        let betaTesters: BetaGroupCreateRequest.Data.Relationships.BetaTesters?
+        public let betaTesters: BetaGroupCreateRequest.Data.Relationships.BetaTesters?
     
         /// BetaGroupCreateRequest.Data.Relationships.Builds
-        let builds: BetaGroupCreateRequest.Data.Relationships.Builds?
+        public let builds: BetaGroupCreateRequest.Data.Relationships.Builds?
     }
 }
 
 /// MARK: BetaGroupCreateRequest.Data.Relationships
 extension BetaGroupCreateRequest.Data.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// BetaGroupCreateRequest.Data.Relationships.App.Data (Required)
-        let data: BetaGroupCreateRequest.Data.Relationships.App.Data
+        public let data: BetaGroupCreateRequest.Data.Relationships.App.Data
     }
     
-    struct BetaTesters: Decodable {
+    public struct BetaTesters: Decodable {
     
         /// [BetaGroupCreateRequest.Data.Relationships.BetaTesters.Data]
-        let data: [BetaGroupCreateRequest.Data.Relationships.BetaTesters.Data]?
+        public let data: [BetaGroupCreateRequest.Data.Relationships.BetaTesters.Data]?
     }
     
-    struct Builds: Decodable {
+    public struct Builds: Decodable {
     
         /// [BetaGroupCreateRequest.Data.Relationships.Builds.Data]
-        let data: [BetaGroupCreateRequest.Data.Relationships.Builds.Data]?
+        public let data: [BetaGroupCreateRequest.Data.Relationships.Builds.Data]?
     }
 }
 
 /// MARK: BetaGroupCreateRequest.Data.Relationships.App
 extension BetaGroupCreateRequest.Data.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaGroupCreateRequest.Data.Relationships.BetaTesters
 extension BetaGroupCreateRequest.Data.Relationships.BetaTesters {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaGroupCreateRequest.Data.Relationships.Builds
 extension BetaGroupCreateRequest.Data.Relationships.Builds {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaGroupResponse.swift
+++ b/Sources/Models/BetaGroupResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BetaGroupResponse: Decodable {
+public struct BetaGroupResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaGroup
+    public let data: BetaGroup
 
     /// The requested relationship data.￼
     ///  Possible types: App, Build, BetaTester
-    let include: [BetaGroupResponse.Included]?
+    public let include: [BetaGroupResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case app(App)
         case build(Build)
         case betaTester(BetaTester)
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let app = try? App(from: decoder) {
                 self = .app(app)
                 return

--- a/Sources/Models/BetaGroupUpdateRequest.swift
+++ b/Sources/Models/BetaGroupUpdateRequest.swift
@@ -8,39 +8,39 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaGroupUpdateRequest: Decodable {
+public struct BetaGroupUpdateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaGroupUpdateRequest.Data
+    public let data: BetaGroupUpdateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// The resource's attributes.
-        let attributes: BetaGroupUpdateRequest.Data.Attributes?
+        public let attributes: BetaGroupUpdateRequest.Data.Attributes?
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaGroups
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaGroupUpdateRequest.Data
 extension BetaGroupUpdateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// The name for the beta group.
-        let name: String?
+        public let name: String?
     
         /// A Boolean value that indicates whether a public link is enabled. Enabling a link allows you to invite anyone outside of your team to beta test your app. When you share this link, testers will be able to install the beta version of your app on their devices in TestFlight and share the link with others.
-        let publicLinkEnabled: Bool?
+        public let publicLinkEnabled: Bool?
     
         /// The maximum number of testers that can join this beta group using the public link. Values must be between 1 and 10,000.
-        let publicLinkLimit: Int?
+        public let publicLinkLimit: Int?
     
         /// A Boolean value that limits the number of testers who can join the beta group using the public link.
-        let publicLinkLimitEnabled: Bool?
+        public let publicLinkLimitEnabled: Bool?
     }
 }

--- a/Sources/Models/BetaGroupsResponse.swift
+++ b/Sources/Models/BetaGroupsResponse.swift
@@ -8,26 +8,26 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct BetaGroupsResponse: Decodable {
+public struct BetaGroupsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [BetaGroup]
+    public let data: [BetaGroup]
 
     /// Relationship data to include in the response.￼
     ///  Possible types: App, Build, BetaTester
-    let include: [BetaGroupsResponse.Included]?
+    public let include: [BetaGroupsResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case app(App)
         case build(Build)
         case betaTester(BetaTester)
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let app = try? App(from: decoder) {
                 self = .app(app)
                 return

--- a/Sources/Models/BetaInviteType.swift
+++ b/Sources/Models/BetaInviteType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum BetaInviteType: String, Decodable {
+public enum BetaInviteType: String, Decodable {
     case email = "EMAIL"
     case publicLink = "PUBLIC_LINK"
 }

--- a/Sources/Models/BetaLicenseAgreement.swift
+++ b/Sources/Models/BetaLicenseAgreement.swift
@@ -8,68 +8,68 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BetaLicenseAgreement: Decodable {
+public struct BetaLicenseAgreement: Decodable {
 
     /// The resource's attributes.
-    let attributes: BetaLicenseAgreement.Attributes?
+    public let attributes: BetaLicenseAgreement.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: BetaLicenseAgreement.Relationships?
+    public let relationships: BetaLicenseAgreement.Relationships?
 
     /// (Required) The resource type.Value: betaLicenseAgreements
-    let type: String
+    public let type: String
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// The license agreement text for your beta app that displays to users.
-        let agreementText: String?
+        public let agreementText: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaLicenseAgreement.Relationships.App
-        let app: BetaLicenseAgreement.Relationships.App?
+        public let app: BetaLicenseAgreement.Relationships.App?
     }
 }
 
 /// MARK: BetaLicenseAgreement.Relationships
 extension BetaLicenseAgreement.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// BetaLicenseAgreement.Relationships.App.Data
-        let data: BetaLicenseAgreement.Relationships.App.Data?
+        public let data: BetaLicenseAgreement.Relationships.App.Data?
     
         /// BetaLicenseAgreement.Relationships.App.Links
-        let links: BetaLicenseAgreement.Relationships.App.Links?
+        public let links: BetaLicenseAgreement.Relationships.App.Links?
     }
 }
 
 /// MARK: BetaLicenseAgreement.Relationships.App
 extension BetaLicenseAgreement.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/BetaLicenseAgreementAppLinkageResponse.swift
+++ b/Sources/Models/BetaLicenseAgreementAppLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BetaLicenseAgreementAppLinkageResponse: Decodable {
+public struct BetaLicenseAgreementAppLinkageResponse: Decodable {
 
     /// (Required) A response containing the ID of the related resource.
-    let data: BetaLicenseAgreementAppLinkageResponse.Data
+    public let data: BetaLicenseAgreementAppLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaLicenseAgreementResponse.swift
+++ b/Sources/Models/BetaLicenseAgreementResponse.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BetaLicenseAgreementResponse: Decodable {
+public struct BetaLicenseAgreementResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaLicenseAgreement
+    public let data: BetaLicenseAgreement
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/BetaLicenseAgreementUpdateRequest.swift
+++ b/Sources/Models/BetaLicenseAgreementUpdateRequest.swift
@@ -8,30 +8,30 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaLicenseAgreementUpdateRequest: Decodable {
+public struct BetaLicenseAgreementUpdateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaLicenseAgreementUpdateRequest.Data
+    public let data: BetaLicenseAgreementUpdateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// The resource's attributes.
-        let attributes: BetaLicenseAgreementUpdateRequest.Data.Attributes?
+        public let attributes: BetaLicenseAgreementUpdateRequest.Data.Attributes?
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaLicenseAgreements
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaLicenseAgreementUpdateRequest.Data
 extension BetaLicenseAgreementUpdateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// The license agreement text for your beta app that displays to users.
-        let agreementText: String?
+        public let agreementText: String?
     }
 }

--- a/Sources/Models/BetaLicenseAgreementsResponse.swift
+++ b/Sources/Models/BetaLicenseAgreementsResponse.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct BetaLicenseAgreementsResponse: Decodable {
+public struct BetaLicenseAgreementsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [BetaLicenseAgreement]
+    public let data: [BetaLicenseAgreement]
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
 }

--- a/Sources/Models/BetaReviewState.swift
+++ b/Sources/Models/BetaReviewState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum BetaReviewState: String, Decodable {
+public enum BetaReviewState: String, Decodable {
     case waitingForReview = "WAITING_FOR_REVIEW"
     case inReview = "IN_REVIEW"
     case rejected = "REJECTED"

--- a/Sources/Models/BetaTester.swift
+++ b/Sources/Models/BetaTester.swift
@@ -8,154 +8,154 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BetaTester: Decodable {
+public struct BetaTester: Decodable {
 
     /// The resource's attributes.
-    let attributes: BetaTester.Attributes?
+    public let attributes: BetaTester.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: BetaTester.Relationships?
+    public let relationships: BetaTester.Relationships?
 
     /// (Required) The resource type.Value: betaTesters
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// The beta tester's email address, used for sending beta testing invitations.
-        let email: String?
+        public let email: String?
     
         /// The beta tester's first name.
-        let firstName: String?
+        public let firstName: String?
     
         /// An invite type that indicates if a beta tester was invited by an email invite or used a TestFlight public link to join a beta test.
-        let inviteType: BetaInviteType?
+        public let inviteType: BetaInviteType?
     
         /// The beta tester's last name.
-        let lastName: String?
+        public let lastName: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaTester.Relationships.Apps
-        let apps: BetaTester.Relationships.Apps?
+        public let apps: BetaTester.Relationships.Apps?
     
         /// BetaTester.Relationships.BetaGroups
-        let betaGroups: BetaTester.Relationships.BetaGroups?
+        public let betaGroups: BetaTester.Relationships.BetaGroups?
     
         /// BetaTester.Relationships.Builds
-        let builds: BetaTester.Relationships.Builds?
+        public let builds: BetaTester.Relationships.Builds?
     }
 }
 
 /// MARK: BetaTester.Relationships
 extension BetaTester.Relationships {
     
-    struct Apps: Decodable {
+    public struct Apps: Decodable {
     
         /// [BetaTester.Relationships.Apps.Data]
-        let data: [BetaTester.Relationships.Apps.Data]?
+        public let data: [BetaTester.Relationships.Apps.Data]?
     
         /// BetaTester.Relationships.Apps.Links
-        let links: BetaTester.Relationships.Apps.Links?
+        public let links: BetaTester.Relationships.Apps.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct BetaGroups: Decodable {
+    public struct BetaGroups: Decodable {
     
         /// [BetaTester.Relationships.BetaGroups.Data]
-        let data: [BetaTester.Relationships.BetaGroups.Data]?
+        public let data: [BetaTester.Relationships.BetaGroups.Data]?
     
         /// BetaTester.Relationships.BetaGroups.Links
-        let links: BetaTester.Relationships.BetaGroups.Links?
+        public let links: BetaTester.Relationships.BetaGroups.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct Builds: Decodable {
+    public struct Builds: Decodable {
     
         /// [BetaTester.Relationships.Builds.Data]
-        let data: [BetaTester.Relationships.Builds.Data]?
+        public let data: [BetaTester.Relationships.Builds.Data]?
     
         /// BetaTester.Relationships.Builds.Links
-        let links: BetaTester.Relationships.Builds.Links?
+        public let links: BetaTester.Relationships.Builds.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
 }
 
 /// MARK: BetaTester.Relationships.Apps
 extension BetaTester.Relationships.Apps {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// string (Required)
-        let `id`: String
+        public let `id`: String
     
         /// string (Required)Value: apps
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: BetaTester.Relationships.BetaGroups
 extension BetaTester.Relationships.BetaGroups {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// string (Required)
-        let `id`: String
+        public let `id`: String
     
         /// string (Required)Value: betaGroups
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: BetaTester.Relationships.Builds
 extension BetaTester.Relationships.Builds {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// string (Required)
-        let `id`: String
+        public let `id`: String
     
         /// string (Required)Value: builds
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/BetaTesterAppsLinkagesRequest.swift
+++ b/Sources/Models/BetaTesterAppsLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the IDs of related resources.
-struct BetaTesterAppsLinkagesRequest: Decodable {
+public struct BetaTesterAppsLinkagesRequest: Decodable {
 
     /// (Required) The types and IDs of related resources.
-    let data: [BetaTesterAppsLinkagesRequest.Data]
+    public let data: [BetaTesterAppsLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaTesterAppsLinkagesResponse.swift
+++ b/Sources/Models/BetaTesterAppsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct BetaTesterAppsLinkagesResponse: Decodable {
+public struct BetaTesterAppsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [BetaTesterAppsLinkagesResponse.Data]
+    public let data: [BetaTesterAppsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaTesterBetaGroupsLinkagesRequest.swift
+++ b/Sources/Models/BetaTesterBetaGroupsLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the IDs of related resources.
-struct BetaTesterBetaGroupsLinkagesRequest: Decodable {
+public struct BetaTesterBetaGroupsLinkagesRequest: Decodable {
 
     /// (Required) The types and IDs of related resources.
-    let data: [BetaTesterBetaGroupsLinkagesRequest.Data]
+    public let data: [BetaTesterBetaGroupsLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaGroups
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaTesterBetaGroupsLinkagesResponse.swift
+++ b/Sources/Models/BetaTesterBetaGroupsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct BetaTesterBetaGroupsLinkagesResponse: Decodable {
+public struct BetaTesterBetaGroupsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [BetaTesterBetaGroupsLinkagesResponse.Data]
+    public let data: [BetaTesterBetaGroupsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaGroups
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaTesterBuildsLinkagesRequest.swift
+++ b/Sources/Models/BetaTesterBuildsLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the IDs of related resources.
-struct BetaTesterBuildsLinkagesRequest: Decodable {
+public struct BetaTesterBuildsLinkagesRequest: Decodable {
 
     /// (Required) The types and IDs of related resources.
-    let data: [BetaTesterBuildsLinkagesRequest.Data]
+    public let data: [BetaTesterBuildsLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaTesterBuildsLinkagesResponse.swift
+++ b/Sources/Models/BetaTesterBuildsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct BetaTesterBuildsLinkagesResponse: Decodable {
+public struct BetaTesterBuildsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [BetaTesterBuildsLinkagesResponse.Data]
+    public let data: [BetaTesterBuildsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaTesterCreateRequest.swift
+++ b/Sources/Models/BetaTesterCreateRequest.swift
@@ -8,87 +8,87 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaTesterCreateRequest: Decodable {
+public struct BetaTesterCreateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaTesterCreateRequest.Data
+    public let data: BetaTesterCreateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The resource's attributes.
-        let attributes: BetaTesterCreateRequest.Data.Attributes
+        public let attributes: BetaTesterCreateRequest.Data.Attributes
     
         /// The types and IDs of the related data to update.
-        let relationships: BetaTesterCreateRequest.Data.Relationships?
+        public let relationships: BetaTesterCreateRequest.Data.Relationships?
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaTesterCreateRequest.Data
 extension BetaTesterCreateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// (Required) The beta tester's email address, used for sending beta testing invitations.
-        let email: String
+        public let email: String
     
         /// The beta tester's first name.
-        let firstName: String?
+        public let firstName: String?
     
         /// The beta tester's last name.
-        let lastName: String?
+        public let lastName: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaTesterCreateRequest.Data.Relationships.BetaGroups
-        let betaGroups: BetaTesterCreateRequest.Data.Relationships.BetaGroups?
+        public let betaGroups: BetaTesterCreateRequest.Data.Relationships.BetaGroups?
     
         /// BetaTesterCreateRequest.Data.Relationships.Builds
-        let builds: BetaTesterCreateRequest.Data.Relationships.Builds?
+        public let builds: BetaTesterCreateRequest.Data.Relationships.Builds?
     }
 }
 
 /// MARK: BetaTesterCreateRequest.Data.Relationships
 extension BetaTesterCreateRequest.Data.Relationships {
     
-    struct BetaGroups: Decodable {
+    public struct BetaGroups: Decodable {
     
         /// [BetaTesterCreateRequest.Data.Relationships.BetaGroups.Data]
-        let data: [BetaTesterCreateRequest.Data.Relationships.BetaGroups.Data]?
+        public let data: [BetaTesterCreateRequest.Data.Relationships.BetaGroups.Data]?
     }
 
-    struct Builds: Decodable {
+    public struct Builds: Decodable {
     
         /// [BetaTesterCreateRequest.Data.Relationships.Builds.Data]
-        let data: [BetaTesterCreateRequest.Data.Relationships.Builds.Data]?
+        public let data: [BetaTesterCreateRequest.Data.Relationships.Builds.Data]?
     }
 }
 
 /// MARK: BetaTesterCreateRequest.Data.Relationships.BetaGroups
 extension BetaTesterCreateRequest.Data.Relationships.BetaGroups {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaGroups
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaTesterCreateRequest.Data.Relationships.Builds
 extension BetaTesterCreateRequest.Data.Relationships.Builds {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaTesterInvitation.swift
+++ b/Sources/Models/BetaTesterInvitation.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BetaTesterInvitation: Decodable {
+public struct BetaTesterInvitation: Decodable {
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// (Required) The resource type.Value: betaTesterInvitations
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 }

--- a/Sources/Models/BetaTesterInvitationCreateRequest.swift
+++ b/Sources/Models/BetaTesterInvitationCreateRequest.swift
@@ -8,72 +8,72 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BetaTesterInvitationCreateRequest: Decodable {
+public struct BetaTesterInvitationCreateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaTesterInvitationCreateRequest.Data
+    public let data: BetaTesterInvitationCreateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The types and IDs of the related data to update.
-        let relationships: BetaTesterInvitationCreateRequest.Data.Relationships
+        public let relationships: BetaTesterInvitationCreateRequest.Data.Relationships
     
         /// (Required) The resource type.Value: betaTesterInvitations
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaTesterInvitationCreateRequest.Data
 extension BetaTesterInvitationCreateRequest.Data {
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BetaTesterInvitationCreateRequest.Data.Relationships.App (Required)
-        let app: BetaTesterInvitationCreateRequest.Data.Relationships.App
+        public let app: BetaTesterInvitationCreateRequest.Data.Relationships.App
     
         /// BetaTesterInvitationCreateRequest.Data.Relationships.BetaTester (Required)
-        let betaTester: BetaTesterInvitationCreateRequest.Data.Relationships.BetaTester
+        public let betaTester: BetaTesterInvitationCreateRequest.Data.Relationships.BetaTester
     }
 }
 
 /// MARK: BetaTesterInvitationCreateRequest.Data.Relationships
 extension BetaTesterInvitationCreateRequest.Data.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// BetaTesterInvitationCreateRequest.Data.Relationships.App.Data (Required)
-        let data: BetaTesterInvitationCreateRequest.Data.Relationships.App.Data
+        public let data: BetaTesterInvitationCreateRequest.Data.Relationships.App.Data
     }
     
-    struct BetaTester: Decodable {
+    public struct BetaTester: Decodable {
     
         /// BetaTesterInvitationCreateRequest.Data.Relationships.BetaTester.Data (Required)
-        let data: BetaTesterInvitationCreateRequest.Data.Relationships.BetaTester.Data
+        public let data: BetaTesterInvitationCreateRequest.Data.Relationships.BetaTester.Data
     }
 }
 
 /// MARK: BetaTesterInvitationCreateRequest.Data.Relationships.App
 extension BetaTesterInvitationCreateRequest.Data.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BetaTesterInvitationCreateRequest.Data.Relationships.BetaTester
 extension BetaTesterInvitationCreateRequest.Data.Relationships.BetaTester {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BetaTesterInvitationResponse.swift
+++ b/Sources/Models/BetaTesterInvitationResponse.swift
@@ -8,11 +8,11 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BetaTesterInvitationResponse: Decodable {
+public struct BetaTesterInvitationResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaTesterInvitation
+    public let data: BetaTesterInvitation
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/BetaTesterResponse.swift
+++ b/Sources/Models/BetaTesterResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BetaTesterResponse: Decodable {
+public struct BetaTesterResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BetaTester
+    public let data: BetaTester
 
     /// The requested relationship data.￼
     ///  Possible types: App, BetaGroup, Build
-    let include: [BetaTesterResponse.Included]?
+    public let include: [BetaTesterResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case app(App)
         case betaGroup(BetaGroup)
         case build(Build)
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let wrapped = try? App(from: decoder) {
                 self = .app(wrapped)
                 return

--- a/Sources/Models/BetaTestersResponse.swift
+++ b/Sources/Models/BetaTestersResponse.swift
@@ -8,26 +8,26 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct BetaTestersResponse: Decodable {
+public struct BetaTestersResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [BetaTester]
+    public let data: [BetaTester]
 
     /// The requested relationship data.￼
     ///  Possible types: App, BetaGroup, Build
-    let include: [BetaTestersResponse.Included]?
+    public let include: [BetaTestersResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case app(App)
         case betaGroup(BetaGroup)
         case build(Build)
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let wrapped = try? App(from: decoder) {
                 self = .app(wrapped)
                 return

--- a/Sources/Models/Build.swift
+++ b/Sources/Models/Build.swift
@@ -8,76 +8,76 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct Build: Decodable {
+public struct Build: Decodable {
 
     /// The resource's attributes.
-    let attributes: Build.Attributes?
+    public let attributes: Build.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: Build.Relationships?
+    public let relationships: Build.Relationships?
 
     /// (Required) The resource type.Value: builds
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A Boolean value that indicates if the build has expired. An expired build is unavailable for testing.
-        let expired: Bool?
+        public let expired: Bool?
     
         /// The icon of the uploaded build.
-        let iconAssetToken: ImageAsset?
+        public let iconAssetToken: ImageAsset?
     
         /// The minimum operating system version needed to test a build.
-        let minOsVersion: String?
+        public let minOsVersion: String?
     
         /// The processing state of the build indicating that it is not yet available for testing. Possible values: PROCESSING, FAILED, INVALID, VALID
-        let processingState: String?
+        public let processingState: String?
     
         /// The version number of the uploaded build.
-        let version: String?
+        public let version: String?
     
         /// A Boolean value that indicates whether the build uses non-exempt encryption.
-        let usesNonExemptEncryption: Bool?
+        public let usesNonExemptEncryption: Bool?
     
         /// The date and time the build was uploaded to App Store Connect.
-        let uploadedDate: Date?
+        public let uploadedDate: Date?
     
         /// The date and time the build  will auto-expire and no longer be available for testing.
-        let expirationDate: Date?
+        public let expirationDate: Date?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// Build.Relationships.App
-        let app: Build.Relationships.App?
+        public let app: Build.Relationships.App?
     
         /// Build.Relationships.AppEncryptionDeclaration
-        let appEncryptionDeclaration: Build.Relationships.AppEncryptionDeclaration?
+        public let appEncryptionDeclaration: Build.Relationships.AppEncryptionDeclaration?
     
         /// Build.Relationships.IndividualTesters
-        let individualTesters: Build.Relationships.IndividualTesters?
+        public let individualTesters: Build.Relationships.IndividualTesters?
     
         /// Build.Relationships.PreReleaseVersion
-        let preReleaseVersion: Build.Relationships.PreReleaseVersion?
+        public let preReleaseVersion: Build.Relationships.PreReleaseVersion?
     
         /// Build.Relationships.BetaBuildLocalizations
-        let betaBuildLocalizations: Build.Relationships.BetaBuildLocalizations?
+        public let betaBuildLocalizations: Build.Relationships.BetaBuildLocalizations?
     
         /// Build.Relationships.BetaGroups
-        let betaGroups: Build.Relationships.BetaGroups?
+        public let betaGroups: Build.Relationships.BetaGroups?
     
         /// Build.Relationships.BuildBetaDetail
-        let buildBetaDetail: Build.Relationships.BuildBetaDetail?
+        public let buildBetaDetail: Build.Relationships.BuildBetaDetail?
     
         /// Build.Relationships.BetaAppReviewSubmission
-        let betaAppReviewSubmission: Build.Relationships.BetaAppReviewSubmission?
+        public let betaAppReviewSubmission: Build.Relationships.BetaAppReviewSubmission?
     }
 }
 
@@ -86,292 +86,292 @@ struct Build: Decodable {
 /// MARK: Build.Relationships
 extension Build.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// Build.Relationships.App.Data
-        let data: Build.Relationships.App.Data?
+        public let data: Build.Relationships.App.Data?
     
         /// Build.Relationships.App.Links
-        let links: Build.Relationships.App.Links?
+        public let links: Build.Relationships.App.Links?
     }
     
-    struct AppEncryptionDeclaration: Decodable {
+    public struct AppEncryptionDeclaration: Decodable {
     
         /// Build.Relationships.AppEncryptionDeclaration.Data
-        let data: Build.Relationships.AppEncryptionDeclaration.Data?
+        public let data: Build.Relationships.AppEncryptionDeclaration.Data?
     
         /// Build.Relationships.AppEncryptionDeclaration.Links
-        let links: Build.Relationships.AppEncryptionDeclaration.Links?
+        public let links: Build.Relationships.AppEncryptionDeclaration.Links?
     }
     
-    struct BetaAppReviewSubmission: Decodable {
+    public struct BetaAppReviewSubmission: Decodable {
     
         /// Build.Relationships.BetaAppReviewSubmission.Data
-        let data: Build.Relationships.BetaAppReviewSubmission.Data?
+        public let data: Build.Relationships.BetaAppReviewSubmission.Data?
     
         /// Build.Relationships.BetaAppReviewSubmission.Links
-        let links: Build.Relationships.BetaAppReviewSubmission.Links?
+        public let links: Build.Relationships.BetaAppReviewSubmission.Links?
     }
     
-    struct BetaBuildLocalizations: Decodable {
+    public struct BetaBuildLocalizations: Decodable {
     
         /// [Build.Relationships.BetaBuildLocalizations.Data]
-        let data: [Build.Relationships.BetaBuildLocalizations.Data]?
+        public let data: [Build.Relationships.BetaBuildLocalizations.Data]?
     
         /// Build.Relationships.BetaBuildLocalizations.Links
-        let links: Build.Relationships.BetaBuildLocalizations.Links?
+        public let links: Build.Relationships.BetaBuildLocalizations.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct BetaGroups: Decodable {
+    public struct BetaGroups: Decodable {
     
         /// [Build.Relationships.BetaGroups.Data]
-        let data: [Build.Relationships.BetaGroups.Data]?
+        public let data: [Build.Relationships.BetaGroups.Data]?
     
         /// Build.Relationships.BetaGroups.Links
-        let links: Build.Relationships.BetaGroups.Links?
+        public let links: Build.Relationships.BetaGroups.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct BuildBetaDetail: Decodable {
+    public struct BuildBetaDetail: Decodable {
     
         /// Build.Relationships.BuildBetaDetail.Data
-        let data: Build.Relationships.BuildBetaDetail.Data?
+        public let data: Build.Relationships.BuildBetaDetail.Data?
     
         /// Build.Relationships.BuildBetaDetail.Links
-        let links: Build.Relationships.BuildBetaDetail.Links?
+        public let links: Build.Relationships.BuildBetaDetail.Links?
     }
     
-    struct IndividualTesters: Decodable {
+    public struct IndividualTesters: Decodable {
     
         /// [Build.Relationships.IndividualTesters.Data]
-        let data: [Build.Relationships.IndividualTesters.Data]?
+        public let data: [Build.Relationships.IndividualTesters.Data]?
     
         /// Build.Relationships.IndividualTesters.Links
-        let links: Build.Relationships.IndividualTesters.Links?
+        public let links: Build.Relationships.IndividualTesters.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
     
-    struct PreReleaseVersion: Decodable {
+    public struct PreReleaseVersion: Decodable {
     
         /// Build.Relationships.PreReleaseVersion.Data
-        let data: Build.Relationships.PreReleaseVersion.Data?
+        public let data: Build.Relationships.PreReleaseVersion.Data?
     
         /// Build.Relationships.PreReleaseVersion.Links
-        let links: Build.Relationships.PreReleaseVersion.Links?
+        public let links: Build.Relationships.PreReleaseVersion.Links?
     }
 }
 
 /// MARK: Build.Relationships.App
 extension Build.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: Build.Relationships.App
 extension Build.Relationships.App {
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: Build.Relationships.AppEncryptionDeclaration
 extension Build.Relationships.AppEncryptionDeclaration {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: appEncryptionDeclarations
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: Build.Relationships.AppEncryptionDeclaration
 extension Build.Relationships.AppEncryptionDeclaration {
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: Build.Relationships.BetaAppReviewSubmission
 extension Build.Relationships.BetaAppReviewSubmission {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaAppReviewSubmissions
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: Build.Relationships.BetaAppReviewSubmission
 extension Build.Relationships.BetaAppReviewSubmission {
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: Build.Relationships.BetaBuildLocalizations
 extension Build.Relationships.BetaBuildLocalizations {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaBuildLocalizations
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: Build.Relationships.BetaBuildLocalizations
 extension Build.Relationships.BetaBuildLocalizations {
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: Build.Relationships.BetaGroups
 extension Build.Relationships.BetaGroups {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaGroups
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: Build.Relationships.BetaGroups
 extension Build.Relationships.BetaGroups {
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: Build.Relationships.BuildBetaDetail
 extension Build.Relationships.BuildBetaDetail {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: buildBetaDetails
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: Build.Relationships.BuildBetaDetail
 extension Build.Relationships.BuildBetaDetail {
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: Build.Relationships.IndividualTesters
 extension Build.Relationships.IndividualTesters {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: Build.Relationships.IndividualTesters
 extension Build.Relationships.IndividualTesters {
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: Build.Relationships.PreReleaseVersion
 extension Build.Relationships.PreReleaseVersion {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: preReleaseVersions
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: Build.Relationships.PreReleaseVersion
 extension Build.Relationships.PreReleaseVersion {
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/BuildAppEncryptionDeclarationLinkageRequest.swift
+++ b/Sources/Models/BuildAppEncryptionDeclarationLinkageRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the ID of the related resource.
-struct BuildAppEncryptionDeclarationLinkageRequest: Decodable {
+public struct BuildAppEncryptionDeclarationLinkageRequest: Decodable {
 
     /// (Required) The types and IDs of related resources.
-    let data: BuildAppEncryptionDeclarationLinkageRequest.Data
+    public let data: BuildAppEncryptionDeclarationLinkageRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: appEncryptionDeclarations
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildAppEncryptionDeclarationLinkageResponse.swift
+++ b/Sources/Models/BuildAppEncryptionDeclarationLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BuildAppEncryptionDeclarationLinkageResponse: Decodable {
+public struct BuildAppEncryptionDeclarationLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BuildAppEncryptionDeclarationLinkageResponse.Data
+    public let data: BuildAppEncryptionDeclarationLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: appEncryptionDeclarations
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildAppLinkageResponse.swift
+++ b/Sources/Models/BuildAppLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BuildAppLinkageResponse: Decodable {
+public struct BuildAppLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BuildAppLinkageResponse.Data
+    public let data: BuildAppLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildBetaAppReviewSubmissionLinkageResponse.swift
+++ b/Sources/Models/BuildBetaAppReviewSubmissionLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BuildBetaAppReviewSubmissionLinkageResponse: Decodable {
+public struct BuildBetaAppReviewSubmissionLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BuildBetaAppReviewSubmissionLinkageResponse.Data
+    public let data: BuildBetaAppReviewSubmissionLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaAppReviewSubmissions
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildBetaBuildLocalizationsLinkagesResponse.swift
+++ b/Sources/Models/BuildBetaBuildLocalizationsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct BuildBetaBuildLocalizationsLinkagesResponse: Decodable {
+public struct BuildBetaBuildLocalizationsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [BuildBetaBuildLocalizationsLinkagesResponse.Data]
+    public let data: [BuildBetaBuildLocalizationsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaBuildLocalizations
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildBetaDetail.swift
+++ b/Sources/Models/BuildBetaDetail.swift
@@ -8,74 +8,74 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BuildBetaDetail: Decodable {
+public struct BuildBetaDetail: Decodable {
 
     /// The resource's attributes.
-    let attributes: BuildBetaDetail.Attributes?
+    public let attributes: BuildBetaDetail.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: BuildBetaDetail.Relationships?
+    public let relationships: BuildBetaDetail.Relationships?
 
     /// (Required) The resource type.Value: buildBetaDetails
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A Boolean value that enables you to send test invitations to users automatically when the build is available to external groups.
-        let autoNotifyEnabled: Bool?
+        public let autoNotifyEnabled: Bool?
     
         /// A state that indicates if the build is available for external testing.
-        let externalBuildState: ExternalBetaState?
+        public let externalBuildState: ExternalBetaState?
     
         /// A state that indicates if the build is available for internal testing.
-        let internalBuildState: InternalBetaState?
+        public let internalBuildState: InternalBetaState?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BuildBetaDetail.Relationships.Build
-        let build: BuildBetaDetail.Relationships.Build?
+        public let build: BuildBetaDetail.Relationships.Build?
     }
 }
 
 /// MARK: BuildBetaDetail.Relationships
 extension BuildBetaDetail.Relationships {
     
-    struct Build: Decodable {
+    public struct Build: Decodable {
     
         /// BuildBetaDetail.Relationships.Build.Data
-        let data: BuildBetaDetail.Relationships.Build.Data?
+        public let data: BuildBetaDetail.Relationships.Build.Data?
     
         /// BuildBetaDetail.Relationships.Build.Links
-        let links: BuildBetaDetail.Relationships.Build.Links?
+        public let links: BuildBetaDetail.Relationships.Build.Links?
     }
 }
 
 /// MARK: BuildBetaDetail.Relationships.Build
 extension BuildBetaDetail.Relationships.Build {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/BuildBetaDetailBuildLinkageResponse.swift
+++ b/Sources/Models/BuildBetaDetailBuildLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BuildBetaDetailBuildLinkageResponse: Decodable {
+public struct BuildBetaDetailBuildLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BuildBetaDetailBuildLinkageResponse.Data
+    public let data: BuildBetaDetailBuildLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildBetaDetailResponse.swift
+++ b/Sources/Models/BuildBetaDetailResponse.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BuildBetaDetailResponse: Decodable {
+public struct BuildBetaDetailResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BuildBetaDetail
+    public let data: BuildBetaDetail
 
     /// The requested relationship data.
-    let include: [Build]?
+    public let include: [Build]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/BuildBetaDetailUpdateRequest.swift
+++ b/Sources/Models/BuildBetaDetailUpdateRequest.swift
@@ -8,30 +8,30 @@
 import Foundation
     
 /// A request containing a single resource
-struct BuildBetaDetailUpdateRequest: Decodable {
+public struct BuildBetaDetailUpdateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BuildBetaDetailUpdateRequest.Data
+    public let data: BuildBetaDetailUpdateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// The resource's attributes.
-        let attributes: BuildBetaDetailUpdateRequest.Data.Attributes?
+        public let attributes: BuildBetaDetailUpdateRequest.Data.Attributes?
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: buildBetaDetails
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BuildBetaDetailUpdateRequest.Data
 extension BuildBetaDetailUpdateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A Boolean value that enables you to send test invitations to users automatically when the build is available to external groups.
-        let autoNotifyEnabled: Bool?
+        public let autoNotifyEnabled: Bool?
     }
 }

--- a/Sources/Models/BuildBetaDetailsResponse.swift
+++ b/Sources/Models/BuildBetaDetailsResponse.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct BuildBetaDetailsResponse: Decodable {
+public struct BuildBetaDetailsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [BuildBetaDetail]
+    public let data: [BuildBetaDetail]
 
     /// The requested relationship data.
-    let include: [Build]?
+    public let include: [Build]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
 }

--- a/Sources/Models/BuildBetaGroupsLinkagesRequest.swift
+++ b/Sources/Models/BuildBetaGroupsLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the IDs of related resources.
-struct BuildBetaGroupsLinkagesRequest: Decodable {
+public struct BuildBetaGroupsLinkagesRequest: Decodable {
 
     /// (Required) The types and IDs of related resources.
-    let data: [BuildBetaGroupsLinkagesRequest.Data]
+    public let data: [BuildBetaGroupsLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaGroups
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildBetaNotification.swift
+++ b/Sources/Models/BuildBetaNotification.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct BuildBetaNotification: Decodable {
+public struct BuildBetaNotification: Decodable {
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// (Required) The resource type.Value: buildBetaNotifications
-    let type: String
+    public let type: String
 }

--- a/Sources/Models/BuildBetaNotificationCreateRequest.swift
+++ b/Sources/Models/BuildBetaNotificationCreateRequest.swift
@@ -8,50 +8,50 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BuildBetaNotificationCreateRequest: Decodable {
+public struct BuildBetaNotificationCreateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BuildBetaNotificationCreateRequest.Data
+    public let data: BuildBetaNotificationCreateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The types and IDs of the related data to update.
-        let relationships: BuildBetaNotificationCreateRequest.Data.Relationships
+        public let relationships: BuildBetaNotificationCreateRequest.Data.Relationships
     
         /// (Required) The resource type.Value: buildBetaNotifications
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BuildBetaNotificationCreateRequest.Data
 extension BuildBetaNotificationCreateRequest.Data {
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BuildBetaNotificationCreateRequest.Data.Relationships.Build (Required)
-        let build: BuildBetaNotificationCreateRequest.Data.Relationships.Build
+        public let build: BuildBetaNotificationCreateRequest.Data.Relationships.Build
     }
 }
 
 /// MARK: BuildBetaNotificationCreateRequest.Data.Relationships
 extension BuildBetaNotificationCreateRequest.Data.Relationships {
     
-    struct Build: Decodable {
+    public struct Build: Decodable {
     
         /// BuildBetaNotificationCreateRequest.Data.Relationships.Build.Data (Required)
-        let data: BuildBetaNotificationCreateRequest.Data.Relationships.Build.Data
+        public let data: BuildBetaNotificationCreateRequest.Data.Relationships.Build.Data
     }
 }
 
 /// MARK: BuildBetaNotificationCreateRequest.Data.Relationships.Build
 extension BuildBetaNotificationCreateRequest.Data.Relationships.Build {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The types and IDs of the related data to update.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildBetaNotificationResponse.swift
+++ b/Sources/Models/BuildBetaNotificationResponse.swift
@@ -8,11 +8,11 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BuildBetaNotificationResponse: Decodable {
+public struct BuildBetaNotificationResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: BuildBetaNotification
+    public let data: BuildBetaNotification
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/BuildBuildBetaDetailLinkageResponse.swift
+++ b/Sources/Models/BuildBuildBetaDetailLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BuildBuildBetaDetailLinkageResponse: Decodable {
+public struct BuildBuildBetaDetailLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BuildBuildBetaDetailLinkageResponse.Data
+    public let data: BuildBuildBetaDetailLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: buildBetaDetails
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildIndividualTestersLinkagesRequest.swift
+++ b/Sources/Models/BuildIndividualTestersLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the IDs of related resources.
-struct BuildIndividualTestersLinkagesRequest: Decodable {
+public struct BuildIndividualTestersLinkagesRequest: Decodable {
 
     /// (Required) The types and IDs of related resources.
-    let data: [BuildIndividualTestersLinkagesRequest.Data]
+    public let data: [BuildIndividualTestersLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildIndividualTestersLinkagesResponse.swift
+++ b/Sources/Models/BuildIndividualTestersLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct BuildIndividualTestersLinkagesResponse: Decodable {
+public struct BuildIndividualTestersLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [BuildIndividualTestersLinkagesResponse.Data]
+    public let data: [BuildIndividualTestersLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: betaTesters
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildPreReleaseVersionLinkageResponse.swift
+++ b/Sources/Models/BuildPreReleaseVersionLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct BuildPreReleaseVersionLinkageResponse: Decodable {
+public struct BuildPreReleaseVersionLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: BuildPreReleaseVersionLinkageResponse.Data
+    public let data: BuildPreReleaseVersionLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: preReleaseVersions
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildResponse.swift
+++ b/Sources/Models/BuildResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a single resource.
-struct BuildResponse: Decodable {
+public struct BuildResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: Build
+    public let data: Build
 
     /// The requested relationship data.￼
     ///  Possible types: PrereleaseVersion, BetaTester, BetaBuildLocalization, AppEncryptionDeclaration, BetaAppReviewSubmission, App, BuildBetaDetail
-    let include: [BuildResponse.Included]?
+    public let include: [BuildResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case app(App)
         case build(Build)
         case betaTester(BetaTester)
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let wrapped = try? App(from: decoder) {
                 self = .app(wrapped)
                 return

--- a/Sources/Models/BuildUpdateRequest.swift
+++ b/Sources/Models/BuildUpdateRequest.swift
@@ -8,65 +8,65 @@
 import Foundation
     
 /// A request containing a single resource.
-struct BuildUpdateRequest: Decodable {
+public struct BuildUpdateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: BuildUpdateRequest.Data
+    public let data: BuildUpdateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// The resource's attributes.
-        let attributes: BuildUpdateRequest.Data.Attributes?
+        public let attributes: BuildUpdateRequest.Data.Attributes?
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// Navigational links to related data and included resource types and IDs.
-        let relationships: BuildUpdateRequest.Data.Relationships?
+        public let relationships: BuildUpdateRequest.Data.Relationships?
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: BuildUpdateRequest.Data
 extension BuildUpdateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A Boolean value that indicates if the build has expired. An expired build is unavailable for testing.
-        let expired: Bool?
+        public let expired: Bool?
     
         /// A Boolean value that indicates whether the build uses non-exempt encryption.
-        let usesNonExemptEncryption: Bool?
+        public let usesNonExemptEncryption: Bool?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// BuildUpdateRequest.Data.Relationships.AppEncryptionDeclaration
-        let appEncryptionDeclaration: BuildUpdateRequest.Data.Relationships.AppEncryptionDeclaration?
+        public let appEncryptionDeclaration: BuildUpdateRequest.Data.Relationships.AppEncryptionDeclaration?
     }
 }
 
 /// MARK: BuildUpdateRequest.Data.Relationships
 extension BuildUpdateRequest.Data.Relationships {
     
-    struct AppEncryptionDeclaration: Decodable {
+    public struct AppEncryptionDeclaration: Decodable {
     
         /// BuildUpdateRequest.Data.Relationships.AppEncryptionDeclaration.Data
-        let data: BuildUpdateRequest.Data.Relationships.AppEncryptionDeclaration.Data?
+        public let data: BuildUpdateRequest.Data.Relationships.AppEncryptionDeclaration.Data?
     }
 }
 
 /// MARK: BuildUpdateRequest.Data.Relationships.AppEncryptionDeclaration
 extension BuildUpdateRequest.Data.Relationships.AppEncryptionDeclaration {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: appEncryptionDeclarations
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/BuildsResponse.swift
+++ b/Sources/Models/BuildsResponse.swift
@@ -8,26 +8,26 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct BuildsResponse: Decodable {
+public struct BuildsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [Build]
+    public let data: [Build]
 
     /// The requested relationship data.￼
     ///  Possible types: PrereleaseVersion, BetaTester, BetaBuildLocalization, AppEncryptionDeclaration, BetaAppReviewSubmission, App, BuildBetaDetail
-    let include: [BuildsResponse.Included]?
+    public let include: [BuildsResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case app(App)
         case build(Build)
         case betaTester(BetaTester)
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let wrapped = try? App(from: decoder) {
                 self = .app(wrapped)
                 return

--- a/Sources/Models/DocumentLinks.swift
+++ b/Sources/Models/DocumentLinks.swift
@@ -8,8 +8,8 @@
 import Foundation
     
 /// Self-links to documents that can contain information for one or more resources.
-struct DocumentLinks: Decodable {
+public struct DocumentLinks: Decodable {
 
     /// (Required) The link that produced the current document.
-    let `self`: URL
+    public let `self`: URL
 }

--- a/Sources/Models/ErrorResponse.swift
+++ b/Sources/Models/ErrorResponse.swift
@@ -8,56 +8,56 @@
 import Foundation
     
 /// Detailed error information returned in the response body whenever an API request is not successful.
-struct ErrorResponse: Decodable {
+public struct ErrorResponse: Decodable {
 
     /// An array of one or more errors.
-    let errors: [ErrorResponse.Errors]?
+    public let errors: [ErrorResponse.Errors]?
 
     /// The details about one error that is returned when an API request is not successful.
-    struct Errors: Decodable {
+    public struct Errors: Decodable {
     
         /// (Required) A machine-readable code indicating the type of error. The code is a hierarchical value with levels of specificity separated by the '.' character. This value is parseable for programmatic error handling in code.
-        let code: String
+        public let code: String
     
         /// (Required) The HTTP status code of the error. This status code usually matches the response's status code; however, if the request produces multiple errors, these two codes may differ.
-        let status: String
+        public let status: String
     
         /// The unique ID of a specific instance of an error, request, and response. Use this ID when providing feedback to or debugging issues with Apple.
-        let `id`: String?
+        public let `id`: String?
     
         /// (Required) A summary of the error. Do not use this field for programmatic error handling.
-        let title: String
+        public let title: String
     
         /// (Required) A detailed explanation of the error. Do not use this field for programmatic error handling.
-        let detail: String
+        public let detail: String
     
         /// One of two possible types of values: source.parameter, provided when a query parameter produced the error, or source.JsonPointer, provided when a problem with the entity produced the error.￼
         ///  Possible types: ErrorResponse.Errors.JsonPointer, ErrorResponse.Errors.Parameter
-        let source: Source?
+        public let source: Source?
     }
 }
 
 /// MARK: ErrorResponse.Errors
 extension ErrorResponse.Errors {
     /// An object containing the JSON pointer that indicates the location of the error.
-    struct JsonPointer: Decodable {
+    public struct JsonPointer: Decodable {
     
         /// A JSON pointer that indicates the location in the request entity where the error originates.
-        let pointer: String?
+        public let pointer: String?
     }
 
     /// An object containing the query parameter that produced the error.
-    struct Parameter: Decodable {
+    public struct Parameter: Decodable {
     
         /// The query parameter that produced the error.
-        let parameter: String?
+        public let parameter: String?
     }
 
-    enum Source: Decodable {
+    public enum Source: Decodable {
         case jsonPointer(String?)
         case parameter(String?)
         
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let json = try? JsonPointer(from: decoder) {
                 self = .jsonPointer(json.pointer)
             } else if let parameter = try? Parameter(from: decoder) {

--- a/Sources/Models/ExternalBetaState.swift
+++ b/Sources/Models/ExternalBetaState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
     /// String that represents a build's availability for external testing.
-enum ExternalBetaState: String, Decodable {
+public enum ExternalBetaState: String, Decodable {
     case processing = "PROCESSING"
     case processingException = "PROCESSING_EXCEPTION"
     case missingExportCompliance = "MISSING_EXPORT_COMPLIANCE"

--- a/Sources/Models/ImageAsset.swift
+++ b/Sources/Models/ImageAsset.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// An image asset, including its height, width, and template URL.
-struct ImageAsset: Decodable {
+public struct ImageAsset: Decodable {
 
     /// string
-    let templateUrl: String?
+    public let templateUrl: String?
 
     /// integer
-    let height: Int?
+    public let height: Int?
 
     /// integer
-    let width: Int?
+    public let width: Int?
 }

--- a/Sources/Models/InternalBetaState.swift
+++ b/Sources/Models/InternalBetaState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
     /// String that represents a build's availability for internal testing.
-enum InternalBetaState: String, Decodable {
+public enum InternalBetaState: String, Decodable {
     case processing = "PROCESSING"
     case processingException = "PROCESSING_EXCEPTION"
     case missingExportCompliance = "MISSING_EXPORT_COMPLIANCE"

--- a/Sources/Models/PagedDocumentLinks.swift
+++ b/Sources/Models/PagedDocumentLinks.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// Links related to the response document, including paging links.
-struct PagedDocumentLinks: Decodable {
+public struct PagedDocumentLinks: Decodable {
 
     /// The link to the first page of documents.
-    let first: URL?
+    public let first: URL?
 
     /// The link to the next page of documents.
-    let next: URL?
+    public let next: URL?
 
     /// (Required) The link that produced the current document.
-    let `self`: URL
+    public let `self`: URL
 }

--- a/Sources/Models/PagingInformation.swift
+++ b/Sources/Models/PagingInformation.swift
@@ -8,18 +8,18 @@
 import Foundation
     
 /// Paging information for data responses.
-struct PagingInformation: Decodable {
+public struct PagingInformation: Decodable {
 
     /// (Required) The paging information details.
-    let paging: PagingInformation.Paging
+    public let paging: PagingInformation.Paging
 
     /// Paging details such as the total number of resources and the per-page limit.
-    struct Paging: Decodable {
+    public struct Paging: Decodable {
     
         /// (Required) The total number of resources matching your request.
-        let total: Int
+        public let total: Int
     
         /// (Required) The maximum number of resources to return per page, from 0 to 200.
-        let limit: Int
+        public let limit: Int
     }
 }

--- a/Sources/Models/Platform.swift
+++ b/Sources/Models/Platform.swift
@@ -7,7 +7,7 @@
 
 import Foundation
     /// Strings that represent Apple operating systems.
-enum Platform: String, Decodable {
+public enum Platform: String, Decodable {
     case ios = "IOS"
     case macOs = "MAC_OS"
     case tvOs = "TV_OS"

--- a/Sources/Models/PreReleaseVersionsResponse.swift
+++ b/Sources/Models/PreReleaseVersionsResponse.swift
@@ -8,25 +8,25 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct PreReleaseVersionsResponse: Decodable {
+public struct PreReleaseVersionsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [PrereleaseVersion]
+    public let data: [PrereleaseVersion]
 
     /// The requested relationship data.￼
     ///  Possible types: Build, App
-    let include: [PreReleaseVersionsResponse.Included]?
+    public let include: [PreReleaseVersionsResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case build(Build)
         case app(App)
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let wrapped = try? Build(from: decoder) {
                 self = .build(wrapped)
                 return

--- a/Sources/Models/PrereleaseVersion.swift
+++ b/Sources/Models/PrereleaseVersion.swift
@@ -8,108 +8,108 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct PrereleaseVersion: Decodable {
+public struct PrereleaseVersion: Decodable {
 
     /// The resource's attributes.
-    let attributes: PrereleaseVersion.Attributes?
+    public let attributes: PrereleaseVersion.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: PrereleaseVersion.Relationships?
+    public let relationships: PrereleaseVersion.Relationships?
 
     /// (Required) The resource type.Value: preReleaseVersions
-    let type: String
+    public let type: String
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// The platform of the prerelease version of your app.
-        let platform: Platform?
+        public let platform: Platform?
     
         /// The version number of the prerelease version of your app.
-        let version: String?
+        public let version: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// PrereleaseVersion.Relationships.App
-        let app: PrereleaseVersion.Relationships.App?
+        public let app: PrereleaseVersion.Relationships.App?
     
         /// PrereleaseVersion.Relationships.Builds
-        let builds: PrereleaseVersion.Relationships.Builds?
+        public let builds: PrereleaseVersion.Relationships.Builds?
     }
 }
 
 /// MARK: PrereleaseVersion.Relationships
 extension PrereleaseVersion.Relationships {
     
-    struct App: Decodable {
+    public struct App: Decodable {
     
         /// PrereleaseVersion.Relationships.App.Data
-        let data: PrereleaseVersion.Relationships.App.Data?
+        public let data: PrereleaseVersion.Relationships.App.Data?
     
         /// PrereleaseVersion.Relationships.App.Links
-        let links: PrereleaseVersion.Relationships.App.Links?
+        public let links: PrereleaseVersion.Relationships.App.Links?
     }
 
-    struct Builds: Decodable {
+    public struct Builds: Decodable {
     
         /// [PrereleaseVersion.Relationships.Builds.Data]
-        let data: [PrereleaseVersion.Relationships.Builds.Data]?
+        public let data: [PrereleaseVersion.Relationships.Builds.Data]?
     
         /// PrereleaseVersion.Relationships.Builds.Links
-        let links: PrereleaseVersion.Relationships.Builds.Links?
+        public let links: PrereleaseVersion.Relationships.Builds.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
 }
 
 /// MARK: PrereleaseVersion.Relationships.App
 extension PrereleaseVersion.Relationships.App {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }
 
 /// MARK: PrereleaseVersion.Relationships.Builds
 extension PrereleaseVersion.Relationships.Builds {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/PrereleaseVersionAppLinkageResponse.swift
+++ b/Sources/Models/PrereleaseVersionAppLinkageResponse.swift
@@ -8,20 +8,20 @@
 import Foundation
     
 /// A response containing the ID of the related resource.
-struct PrereleaseVersionAppLinkageResponse: Decodable {
+public struct PrereleaseVersionAppLinkageResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: PrereleaseVersionAppLinkageResponse.Data
+    public let data: PrereleaseVersionAppLinkageResponse.Data
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/PrereleaseVersionBuildsLinkagesResponse.swift
+++ b/Sources/Models/PrereleaseVersionBuildsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct PrereleaseVersionBuildsLinkagesResponse: Decodable {
+public struct PrereleaseVersionBuildsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [PrereleaseVersionBuildsLinkagesResponse.Data]
+    public let data: [PrereleaseVersionBuildsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: builds
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/PrereleaseVersionResponse.swift
+++ b/Sources/Models/PrereleaseVersionResponse.swift
@@ -8,22 +8,22 @@
 import Foundation
     
 /// A response containing a single resource.
-struct PrereleaseVersionResponse: Decodable {
+public struct PrereleaseVersionResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: PrereleaseVersion
+    public let data: PrereleaseVersion
 
     /// The requested relationship data.￼
     ///  Possible types: Build, App
-    let include: [PrereleaseVersionResponse.Included]?
+    public let include: [PrereleaseVersionResponse.Included]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
     
-    enum Included: Decodable {
+    public enum Included: Decodable {
         case build(Build)
         case app(App)
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             if let wrapped = try? Build(from: decoder) {
                 self = .build(wrapped)
                 return

--- a/Sources/Models/ResourceLinks.swift
+++ b/Sources/Models/ResourceLinks.swift
@@ -8,8 +8,8 @@
 import Foundation
     
 /// Self-links to requested resources.
-struct ResourceLinks: Decodable {
+public struct ResourceLinks: Decodable {
 
     /// (Required) The link to the resource.
-    let `self`: URL
+    public let `self`: URL
 }

--- a/Sources/Models/User.swift
+++ b/Sources/Models/User.swift
@@ -8,86 +8,86 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct User: Decodable {
+public struct User: Decodable {
 
     /// The resource's attributes.
-    let attributes: User.Attributes?
+    public let attributes: User.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: User.Relationships?
+    public let relationships: User.Relationships?
 
     /// (Required) The resource type.Value: users
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// The user's first name.
-        let firstName: String?
+        public let firstName: String?
     
         /// The user's last name.
-        let lastName: String?
+        public let lastName: String?
     
         /// Assigned user roles that determine the user's access to sections of App Store Connect and tasks they can perform.
-        let roles: [UserRole]?
+        public let roles: [UserRole]?
     
         /// A Boolean value that indicates the user's specified role allows access to the provisioning functionality on the Apple Developer website.
-        let provisioningAllowed: Bool?
+        public let provisioningAllowed: Bool?
     
         /// A Boolean value that indicates whether a user has access to all apps available to the team.
-        let allAppsVisible: Bool?
+        public let allAppsVisible: Bool?
     
         /// The user's Apple ID.
-        let username: String?
+        public let username: String?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// User.Relationships.VisibleApps
-        let visibleApps: User.Relationships.VisibleApps?
+        public let visibleApps: User.Relationships.VisibleApps?
     }
 }
 
 /// MARK: User.Relationships
 extension User.Relationships {
     
-    struct VisibleApps: Decodable {
+    public struct VisibleApps: Decodable {
     
         /// [User.Relationships.VisibleApps.Data]
-        let data: [User.Relationships.VisibleApps.Data]?
+        public let data: [User.Relationships.VisibleApps.Data]?
     
         /// User.Relationships.VisibleApps.Links
-        let links: User.Relationships.VisibleApps.Links?
+        public let links: User.Relationships.VisibleApps.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
 }
 
 /// MARK: User.Relationships.VisibleApps
 extension User.Relationships.VisibleApps {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/UserInvitation.swift
+++ b/Sources/Models/UserInvitation.swift
@@ -8,89 +8,89 @@
 import Foundation
     
 /// The data structure that represents the resource.
-struct UserInvitation: Decodable {
+public struct UserInvitation: Decodable {
 
     /// The resource's attributes.
-    let attributes: UserInvitation.Attributes?
+    public let attributes: UserInvitation.Attributes?
 
     /// (Required) The opaque resource ID that uniquely identifies the resource.
-    let `id`: String
+    public let `id`: String
 
     /// Navigational links to related data and included resource types and IDs.
-    let relationships: UserInvitation.Relationships?
+    public let relationships: UserInvitation.Relationships?
 
     /// (Required) The resource type.Value: userInvitations
-    let type: String
+    public let type: String
 
     /// (Required) Navigational links that include the self-link.
-    let links: ResourceLinks
+    public let links: ResourceLinks
 
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// The email address of a pending user invitation. The email address must be valid to activate the account. It can be any email address, not necessarily one associated with an Apple ID.
-        let email: String?
+        public let email: String?
     
         /// The first name of the user with the pending user invitation.
-        let firstName: String?
+        public let firstName: String?
     
         /// The last name of the user with the pending user invitation.
-        let lastName: String?
+        public let lastName: String?
     
         /// Assigned user roles that determine the user's access to sections of App Store Connect and tasks they can perform.
-        let roles: [UserRole]?
+        public let roles: [UserRole]?
     
         /// The expiration date of the pending invitation.
-        let expirationDate: Date?
+        public let expirationDate: Date?
     
         /// A Boolean value that indicates the user's specified role allows access to the provisioning functionality on the Apple Developer website.
-        let provisioningAllowed: Bool?
+        public let provisioningAllowed: Bool?
     
         /// A Boolean value that indicates whether a user has access to all apps available to the team.
-        let allAppsVisible: Bool?
+        public let allAppsVisible: Bool?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// UserInvitation.Relationships.VisibleApps
-        let visibleApps: UserInvitation.Relationships.VisibleApps?
+        public let visibleApps: UserInvitation.Relationships.VisibleApps?
     }
 }
 
 /// MARK: UserInvitation.Relationships
 extension UserInvitation.Relationships {
     
-    struct VisibleApps: Decodable {
+    public struct VisibleApps: Decodable {
     
         /// [UserInvitation.Relationships.VisibleApps.Data]
-        let data: [UserInvitation.Relationships.VisibleApps.Data]?
+        public let data: [UserInvitation.Relationships.VisibleApps.Data]?
     
         /// UserInvitation.Relationships.VisibleApps.Links
-        let links: UserInvitation.Relationships.VisibleApps.Links?
+        public let links: UserInvitation.Relationships.VisibleApps.Links?
     
         /// PagingInformation
-        let meta: PagingInformation?
+        public let meta: PagingInformation?
     }
 }
 
 /// MARK: UserInvitation.Relationships.VisibleApps
 extension UserInvitation.Relationships.VisibleApps {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
     
-    struct Links: Decodable {
+    public struct Links: Decodable {
     
         /// uri-reference
-        let related: URL?
+        public let related: URL?
     
         /// uri-reference
-        let `self`: URL?
+        public let `self`: URL?
     }
 }

--- a/Sources/Models/UserInvitationCreateRequest.swift
+++ b/Sources/Models/UserInvitationCreateRequest.swift
@@ -8,74 +8,74 @@
 import Foundation
     
 /// A request containing a single resource.
-struct UserInvitationCreateRequest: Decodable {
+public struct UserInvitationCreateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: UserInvitationCreateRequest.Data
+    public let data: UserInvitationCreateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The resource's attributes.
-        let attributes: UserInvitationCreateRequest.Data.Attributes
+        public let attributes: UserInvitationCreateRequest.Data.Attributes
     
         /// The types and IDs of the related data to update.
-        let relationships: UserInvitationCreateRequest.Data.Relationships?
+        public let relationships: UserInvitationCreateRequest.Data.Relationships?
     
         /// (Required) The resource type.Value: userInvitations
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: UserInvitationCreateRequest.Data
 extension UserInvitationCreateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// A Boolean value that indicates whether a user has access to all apps available to the team.
-        let allAppsVisible: Bool?
+        public let allAppsVisible: Bool?
     
         /// (Required) The email address of a pending user invitation. The email address must be valid to activate the account. It can be any email address, not necessarily one associated with an Apple ID.
-        let email: String
+        public let email: String
     
         /// (Required) The user invitation recipient's first name.
-        let firstName: String
+        public let firstName: String
     
         /// (Required) The user invitation recipient's last name.
-        let lastName: String
+        public let lastName: String
     
         /// A Boolean value that indicates the user's specified role allows access to the provisioning functionality on the Apple Developer website.
-        let provisioningAllowed: Bool?
+        public let provisioningAllowed: Bool?
     
         /// (Required) Assigned user roles that determine the user's access to sections of App Store Connect and tasks they can perform.
-        let roles: [UserRole]
+        public let roles: [UserRole]
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// UserInvitationCreateRequest.Data.Relationships.VisibleApps
-        let visibleApps: UserInvitationCreateRequest.Data.Relationships.VisibleApps?
+        public let visibleApps: UserInvitationCreateRequest.Data.Relationships.VisibleApps?
     }
 }
 
 /// MARK: UserInvitationCreateRequest.Data.Relationships
 extension UserInvitationCreateRequest.Data.Relationships {
     
-    struct VisibleApps: Decodable {
+    public struct VisibleApps: Decodable {
     
         /// [UserInvitationCreateRequest.Data.Relationships.VisibleApps.Data]
-        let data: [UserInvitationCreateRequest.Data.Relationships.VisibleApps.Data]?
+        public let data: [UserInvitationCreateRequest.Data.Relationships.VisibleApps.Data]?
     }
 }
 
 /// MARK: UserInvitationCreateRequest.Data.Relationships.VisibleApps
 extension UserInvitationCreateRequest.Data.Relationships.VisibleApps {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/UserInvitationResponse.swift
+++ b/Sources/Models/UserInvitationResponse.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// A response containing a single resource.
-struct UserInvitationResponse: Decodable {
+public struct UserInvitationResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: UserInvitation
+    public let data: UserInvitation
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/UserInvitationVisibleAppsLinkagesResponse.swift
+++ b/Sources/Models/UserInvitationVisibleAppsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct UserInvitationVisibleAppsLinkagesResponse: Decodable {
+public struct UserInvitationVisibleAppsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [UserInvitationVisibleAppsLinkagesResponse.Data]
+    public let data: [UserInvitationVisibleAppsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/UserInvitationsResponse.swift
+++ b/Sources/Models/UserInvitationsResponse.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct UserInvitationsResponse: Decodable {
+public struct UserInvitationsResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [UserInvitation]
+    public let data: [UserInvitation]
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
 }

--- a/Sources/Models/UserResponse.swift
+++ b/Sources/Models/UserResponse.swift
@@ -8,14 +8,14 @@
 import Foundation
     
 /// A response containing a single resource.
-struct UserResponse: Decodable {
+public struct UserResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: User
+    public let data: User
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: DocumentLinks
+    public let links: DocumentLinks
 }

--- a/Sources/Models/UserRole.swift
+++ b/Sources/Models/UserRole.swift
@@ -7,7 +7,7 @@
 
 import Foundation
     /// Strings representing user roles in App Store Connect.
-enum UserRole: String, Decodable {
+public enum UserRole: String, Decodable {
     case admin = "ADMIN"
     case finance = "FINANCE"
     case technical = "TECHNICAL"

--- a/Sources/Models/UserUpdateRequest.swift
+++ b/Sources/Models/UserUpdateRequest.swift
@@ -8,68 +8,68 @@
 import Foundation
     
 /// A request containing a single resource.
-struct UserUpdateRequest: Decodable {
+public struct UserUpdateRequest: Decodable {
 
     /// (Required) The resource data.
-    let data: UserUpdateRequest.Data
+    public let data: UserUpdateRequest.Data
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// The resource's attributes.
-        let attributes: UserUpdateRequest.Data.Attributes?
+        public let attributes: UserUpdateRequest.Data.Attributes?
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// The types and IDs of the related data to update.
-        let relationships: UserUpdateRequest.Data.Relationships?
+        public let relationships: UserUpdateRequest.Data.Relationships?
     
         /// (Required) The resource type.Value: users
-        let type: String
+        public let type: String
     }
 }
 
 /// MARK: UserUpdateRequest.Data
 extension UserUpdateRequest.Data {
     /// Attributes that describe a resource.
-    struct Attributes: Decodable {
+    public struct Attributes: Decodable {
     
         /// Assigned user roles that determine the user's access to sections of App Store Connect and tasks they can perform.
-        let allAppsVisible: Bool?
+        public let allAppsVisible: Bool?
     
         /// A Boolean value that indicates the user's specified role allows access to the provisioning functionality on the Apple Developer website.
-        let provisioningAllowed: Bool?
+        public let provisioningAllowed: Bool?
     
         /// Assigned user roles that determine the user's access to sections of App Store Connect and tasks they can perform.
-        let roles: [UserRole]?
+        public let roles: [UserRole]?
     }
     
-    struct Relationships: Decodable {
+    public struct Relationships: Decodable {
     
         /// UserUpdateRequest.Data.Relationships.VisibleApps
-        let visibleApps: UserUpdateRequest.Data.Relationships.VisibleApps?
+        public let visibleApps: UserUpdateRequest.Data.Relationships.VisibleApps?
     }
 }
 
 /// MARK: UserUpdateRequest.Data.Relationships
 extension UserUpdateRequest.Data.Relationships {
     
-    struct VisibleApps: Decodable {
+    public struct VisibleApps: Decodable {
     
         /// [UserUpdateRequest.Data.Relationships.VisibleApps.Data]
-        let data: [UserUpdateRequest.Data.Relationships.VisibleApps.Data]?
+        public let data: [UserUpdateRequest.Data.Relationships.VisibleApps.Data]?
     }
 }
 
 /// MARK: UserUpdateRequest.Data.Relationships.VisibleApps
 extension UserUpdateRequest.Data.Relationships.VisibleApps {
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/UserVisibleAppsLinkagesRequest.swift
+++ b/Sources/Models/UserVisibleAppsLinkagesRequest.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A request containing the IDs of related resources.
-struct UserVisibleAppsLinkagesRequest: Decodable {
+public struct UserVisibleAppsLinkagesRequest: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [UserVisibleAppsLinkagesRequest.Data]
+    public let data: [UserVisibleAppsLinkagesRequest.Data]
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/UserVisibleAppsLinkagesResponse.swift
+++ b/Sources/Models/UserVisibleAppsLinkagesResponse.swift
@@ -8,23 +8,23 @@
 import Foundation
     
 /// A response containing a list of related resource IDs.
-struct UserVisibleAppsLinkagesResponse: Decodable {
+public struct UserVisibleAppsLinkagesResponse: Decodable {
 
     /// (Required) The object types and IDs of the related resources.
-    let data: [UserVisibleAppsLinkagesResponse.Data]
+    public let data: [UserVisibleAppsLinkagesResponse.Data]
 
     /// (Required) Navigational links including the self-link and links to the related data.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
     
-    struct Data: Decodable {
+    public struct Data: Decodable {
     
         /// (Required) The opaque resource ID that uniquely identifies the resource.
-        let `id`: String
+        public let `id`: String
     
         /// (Required) The resource type.Value: apps
-        let type: String
+        public let type: String
     }
 }

--- a/Sources/Models/UsersResponse.swift
+++ b/Sources/Models/UsersResponse.swift
@@ -8,17 +8,17 @@
 import Foundation
     
 /// A response containing a list of resources.
-struct UsersResponse: Decodable {
+public struct UsersResponse: Decodable {
 
     /// (Required) The resource data.
-    let data: [User]
+    public let data: [User]
 
     /// The requested relationship data.
-    let include: [App]?
+    public let include: [App]?
 
     /// (Required) Navigational links that include the self-link.
-    let links: PagedDocumentLinks
+    public let links: PagedDocumentLinks
 
     /// Paging information.
-    let meta: PagingInformation?
+    public let meta: PagingInformation?
 }


### PR DESCRIPTION
This PR adds the first endpoint which can be used, the `/apps` endpoint.
All models are now publicly accessible and the readme contains a get started section.