### PR TITLE
Remove outdated fastlane call

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,4 @@
-# Fastlane requirements
 fastlane_version "1.109.0"
-generated_fastfile_id "0121e253-f9e2-40ac-b489-f17f36e24ec6"
 
 import "./../Submodules/WeTransfer-iOS-CI/Fastlane/Fastfile"
 


### PR DESCRIPTION
I don't think this was used anywhere any more, we can safely remove the Fastfile ID