### PR TITLE
Improved endpoints and readme update for CocoaPods

### DIFF
--- a/Example/CocoaPods-AppStoreConnect-Swift-SDK/AppStoreConnect-Swift-SDK/ViewController.swift
+++ b/Example/CocoaPods-AppStoreConnect-Swift-SDK/AppStoreConnect-Swift-SDK/ViewController.swift
@@ -19,7 +19,7 @@ final class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        provider.request(Endpoints.apps()) { (result) in
+        provider.request(.apps()) { (result) in
             switch result {
             case .success(let appsResponse):
                 print("Did fetch \(appsResponse.data.count) apps")

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ After creating an `APIProvider` instance with your `APIConfiguration` you can st
 ```swift
 let provider: APIProvider = APIProvider(configuration: configuration)
 
-provider.request(Endpoints.apps()) { (result) in
+provider.request(.apps()) { (result) in
     switch result {
     case .success(let appsResponse):
         print("Did fetch \(appsResponse.data.count) apps")
@@ -70,11 +70,12 @@ provider.request(Endpoints.apps()) { (result) in
 ## Installation
 
 ### CocoaPods
-AppStoreConnect-Swift-SDK is available through [CocoaPods](https://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+AppStoreConnect-Swift-SDK will be available through [CocoaPods](https://cocoapods.org) when it's more complete. To install
+it now, simply add the following line to your Podfile:
 
 ```ruby
-pod 'AppStoreConnect-Swift-SDK'
+pod 'AppStoreConnect-Swift-SDK', :git => 'https://github.com/AvdLee/appstoreconnect-swift-sdk.git'
+
 ```
 
 ### Swift Package Manager

--- a/Sources/Endpoints.swift
+++ b/Sources/Endpoints.swift
@@ -31,7 +31,7 @@ public struct APIEndpoint<T: Decodable> {
 }
 
 /// Contains all API endpoints to the App Store Connect API
-public enum Endpoints {
+extension APIEndpoint {
 
     /// Find and list apps added in App Store Connect.
     public static func apps() -> APIEndpoint<AppsResponse> {


### PR DESCRIPTION
- [x] Readme now gives instructions for CocoaPods using GIT reference
- [x] Nicer APIEndpoint syntax using an extension on `APIEndpoint`.

Fixes #16 