### PR TITLE
Remove validation code for signatures

### DIFF
--- a/Example/CocoaPods-AppStoreConnect-Swift-SDK/Tests/JWTTests.swift
+++ b/Example/CocoaPods-AppStoreConnect-Swift-SDK/Tests/JWTTests.swift
@@ -24,12 +24,4 @@ final class JWTTests: XCTestCase {
             XCTAssertEqual(error as! JWT.Error, JWT.Error.invalidP8PrivateKey)
         }
     }
-
-    /// It should correctly create a JWT Token.
-    func _testTokenGeneration() {
-        let jwt = JWT(keyIdentifier: configuration.privateKeyID, issuerIdentifier: configuration.issuerID, expireDuration: 0, baseDate: Date(timeIntervalSinceNow: 1541949071))
-        let signedToken = try! jwt.signedToken(using: configuration.privateKey)
-        XCTAssertTrue(try! signedToken.isValid(for: configuration.privateKey))
-    }
-
 }

--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Security
 
 /// The JWT Header contains information specific to the App Store Connect API Keys, such as algorithm and keys.
 private struct Header: Codable {
@@ -155,29 +154,5 @@ private extension JWT.P8PrivateKey {
             throw JWT.Error.invalidP8PrivateKey
         }
         return asn1
-    }
-}
-
-extension JWT.Token {
-    func isValid(for privateKey: String) throws -> Bool {
-        let privateKey = try privateKey.toASN1()
-            .toECKeyData()
-            .toPrivateKey()
-
-        let parts = components(separatedBy: ".")
-        let header = parts[0]
-        let payload = parts[1]
-        let algorithm = SecKeyAlgorithm.ecdsaSignatureDigestX962SHA256
-
-        guard
-            let signature = Data(base64Encoded: parts[2].base64URLDecoded()),
-            let signingInput = (header + "." + payload).data(using: .ascii),
-            let publicKey = SecKeyCopyPublicKey(privateKey),
-            SecKeyIsAlgorithmSupported(publicKey, .verify, algorithm) else {
-                return false
-        }
-
-        return SecKeyVerifySignature(publicKey, .ecdsaSignatureDigestX962SHA256, signingInput as CFData, signature as CFData, nil)
-
     }
 }


### PR DESCRIPTION
When trying to validate the signature, I came to the conclusion that it does not make a whole lot of sense to start writing decoding logic for something we encode first completely and only use for testing.

Fixes #13 