### PR TITLE
Add pagination support to beta testers endpoint

### DIFF
--- a/Sources/Endpoints/TestFlight/BetaTesters/ListBetaTesters.swift
+++ b/Sources/Endpoints/TestFlight/BetaTesters/ListBetaTesters.swift
@@ -17,18 +17,23 @@ extension APIEndpoint where T == BetaTestersResponse {
     ///   - include: Relationship data to include in the response.
     ///   - limit: Number of resources to return.
     ///   - sort: Attributes by which to sort.
+    ///   - next: The next URL to use as a base. See `PagedDocumentLinks`.
     public static func betaTesters(
         fields: [ListBetaTesters.Field]? = nil,
         filter: [ListBetaTesters.Filter]? = nil,
         include: [ListBetaTesters.Include]? = nil,
         limit: [ListBetaTesters.Limit]? = nil,
-        sort: [ListBetaTesters.Sort]? = nil) -> APIEndpoint {
+        sort: [ListBetaTesters.Sort]? = nil,
+        next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
         if let limit = limit { parameters.add(limit) }
         if let sort = sort { parameters.add(sort) }
+        if let nextCursor = next?.nextCursor {
+            parameters["cursor"] = nextCursor
+        }
         return APIEndpoint(path: "betaTesters", method: .get, parameters: parameters)
     }
 }

--- a/Sources/Models/PagedDocumentLinks.swift
+++ b/Sources/Models/PagedDocumentLinks.swift
@@ -19,3 +19,21 @@ public struct PagedDocumentLinks: Codable {
     /// The link that produced the current document.
     public let `self`: URL
 }
+
+extension PagedDocumentLinks {
+    /// Returns the `cursor` value which can be used for pagination.
+    var nextCursor: String? {
+        return next?.value(for: "cursor")
+    }
+}
+
+private extension URL {
+    /// Returns the value for the given parameter key from the query string.
+    func value<T>(for parameter: String) -> T? {
+        let queryItems = URLComponents(url: self, resolvingAgainstBaseURL: false)?.queryItems
+        let queryItem = queryItems?.first { (queryItem) -> Bool in
+            return queryItem.name == parameter
+        }
+        return queryItem?.value as? T
+    }
+}


### PR DESCRIPTION
Pagination works using the base URLs. As the APIProvider is not designed to work like this, we need to get the cursor value from the URL and pass that with the endpoints.

This PR enables that for the beta testers endpoint.