### PR TITLE
Add swiftlint configuration file

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,6 @@
+included:
+    - Sources
+
+disabled_rules:
+    - identifier_name
+    - line_length


### PR DESCRIPTION
Configuration file for quality code tool [swiftlint](https://github.com/realm/SwiftLint)
(I see `gem 'danger-swiftlint'` in Gemfile but no config file)

You will have more than 500 `trailing_whitespace` warnings.
You can fix it by calling `swiftlint autocorrect` and commit the modified files

I disable two rules that can be fixed later if wanted (or ignored line by line with intruction in code // swiftlint/disable... )

The overall code quality is good 👍 

---

I did not commit/pr the change done by `swiftlint autocorrect` because it could add conflicts if you or someone work on a big PR
