### PR TITLE
Add CupertinoJWT to LICENSE and README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,35 @@
+# App Store Connect Swift SDK
+
 MIT License
 
 Copyright (c) 2018 Antoine van der Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+App Store Connect Swift SDK uses source code from these open source projects:
+
+## [CupertinoJWT](https://github.com/ethanhuang13/CupertinoJWT)
+
+MIT License
+
+Copyright (c) 2018 Ethan Huang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ dependencies: [
 
 ## License
 
-**App Store Connect Swift SDK** is available under the MIT license. See the [LICENSE](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/master/LICENSE) file for more info.
+**App Store Connect Swift SDK** is available under the MIT license, and uses source code from open source projects. See the [LICENSE](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/master/LICENSE) file for more info.


### PR DESCRIPTION
Hi @AvdLee, 

I think including CupertinoJWT's license in LICENSE is sufficient. Let me know what you think.

Reference for others: [Twitter thread](https://twitter.com/ethanhuang13/status/1070382633220108288).