### PR TITLE
Allow additional HTTP headers in APIProvider init

### DIFF
--- a/Example/CocoaPods-AppStoreConnect-Swift-SDK/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
+++ b/Example/CocoaPods-AppStoreConnect-Swift-SDK/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		806B0D7413287E5233231BEC /* Pods_AppStoreConnect_Swift_SDK_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9639D4E6C89670B57FE7B4C3 /* Pods_AppStoreConnect_Swift_SDK_Tests.framework */; };
 		D44D55D54A86BD85123A8DB8 /* Pods_AppStoreConnect_Swift_SDK_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECADB7DD6CF6600E0251BBEC /* Pods_AppStoreConnect_Swift_SDK_Example.framework */; };
+		F880EA7421DB5E29008F5E3B /* AdditionalHTTPHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F880EA7321DB5E29008F5E3B /* AdditionalHTTPHeadersTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -325,6 +326,7 @@
 		C76C6971C22EB75918256285 /* Pods-AppStoreConnect-Swift-SDK_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppStoreConnect-Swift-SDK_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AppStoreConnect-Swift-SDK_Example/Pods-AppStoreConnect-Swift-SDK_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		DF1B520C60DCEDD8A035052B /* AppStoreConnect-Swift-SDK.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "AppStoreConnect-Swift-SDK.podspec"; path = "../AppStoreConnect-Swift-SDK.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		ECADB7DD6CF6600E0251BBEC /* Pods_AppStoreConnect_Swift_SDK_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppStoreConnect_Swift_SDK_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F880EA7321DB5E29008F5E3B /* AdditionalHTTPHeadersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalHTTPHeadersTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -700,6 +702,7 @@
 				31F929E1219C6AC40061DEA5 /* JWTTests.swift */,
 				3119F5E421C181BA0064A926 /* Models+Tests.swift */,
 				3183103721A8497800638289 /* QueryParameterTests.swift */,
+				F880EA7321DB5E29008F5E3B /* AdditionalHTTPHeadersTests.swift */,
 				318824BE21AD3C8500676DA7 /* Endpoints */,
 				3119F5F121C182560064A926 /* Models */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
@@ -1078,6 +1081,7 @@
 				311FE2A021B1C7E80078C9C0 /* RemoveUserAccountTests.swift in Sources */,
 				311FE2DD21B1D2950078C9C0 /* ReadBuildInformationOfBetaAppReviewSubmissionTests.swift in Sources */,
 				310FAE2321B16157004327B2 /* GetAppResourceIDForBetaGroupTests.swift in Sources */,
+				F880EA7421DB5E29008F5E3B /* AdditionalHTTPHeadersTests.swift in Sources */,
 				311FE2EA21B1D2950078C9C0 /* AssignIndividualTestersToBuildTests.swift in Sources */,
 				311FE2E721B1D2950078C9C0 /* ReadBetaAppReviewSubmissionOfBuildTests.swift in Sources */,
 				311FE2E321B1D2950078C9C0 /* ReadBuildInformationOfBuildBetaDetailTests.swift in Sources */,

--- a/Example/CocoaPods-AppStoreConnect-Swift-SDK/Tests/AdditionalHTTPHeadersTests.swift
+++ b/Example/CocoaPods-AppStoreConnect-Swift-SDK/Tests/AdditionalHTTPHeadersTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import AppStoreConnect_Swift_SDK
 
-class AdditionalHTTPHeadersTests: XCTestCase {
+final class AdditionalHTTPHeadersTests: XCTestCase {
 
     private let configuration = APIConfiguration(issuerID: UUID().uuidString,
                                                  privateKeyID: UUID().uuidString,

--- a/Example/CocoaPods-AppStoreConnect-Swift-SDK/Tests/AdditionalHTTPHeadersTests.swift
+++ b/Example/CocoaPods-AppStoreConnect-Swift-SDK/Tests/AdditionalHTTPHeadersTests.swift
@@ -1,0 +1,43 @@
+//
+//  AdditionalHTTPHeadersTests.swift
+//  AppStoreConnect-Swift-SDK_Tests
+//
+//  Created by Stefan Paychère on 01.01.19.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import AppStoreConnect_Swift_SDK
+
+class AdditionalHTTPHeadersTests: XCTestCase {
+
+    private let configuration = APIConfiguration(issuerID: UUID().uuidString,
+                                                 privateKeyID: UUID().uuidString,
+                                                 privateKey: "MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgPaXyFvZfNydDEjxgjUCUxyGjXcQxiulEdGxoVbasV3GgCgYIKoZIzj0DAQehRANCAASflx/DU3TUWAoLmqE6hZL9A7i0DWpXtmIDCDiITRznC6K4/WjdIcuMcixy+m6O0IrffxJOablIX2VM8sHRscdr")
+
+    func testDefaultInit() {
+        let apiProvider = APIProvider(configuration: configuration)
+
+        apiProvider.defaultSessionManager.startRequestsImmediately = false // disable actual sending
+        let request = apiProvider.defaultSessionManager.request(URL(string: "127.0.0.1")!)
+        let headers = request.task?.currentRequest?.allHTTPHeaderFields
+
+        XCTAssertTrue(headers?.count ?? 0 >= 1)
+        XCTAssertNotNil(headers?["Authorization"])
+    }
+    
+    func testInitWithHeaders() {
+        let myKey = "X-Private-Header"
+        let myValue = "Some-Value"
+        let myHeaders = [myKey: myValue]
+        let apiProvider = APIProvider(configuration: configuration, httpAdditionalHeaders: myHeaders)
+        
+        apiProvider.defaultSessionManager.startRequestsImmediately = false // disable actual sending
+        let request = apiProvider.defaultSessionManager.request(URL(string: "127.0.0.1")!)
+        let headers = request.task?.currentRequest?.allHTTPHeaderFields
+
+        XCTAssertTrue(headers?.count ?? 0 >= 2)
+        XCTAssertEqual(headers?[myKey], myValue)
+    }
+
+}


### PR DESCRIPTION
Summary:
Allow the APIProvider to have additional default HTTP headers.

Reasons:
I am using the SDK in an iOS app to automate TestFlight access. It turns out the the ASC API fails with a 500 error if the "User-Agent" header is absent or if the OS portion of the "User-Agent" is iOS (works with "OS X").
To bypass that problem I had to fake an OS X User Agent and therefore needed to create an APIProvider with custom headers.

Changes:
- Add custom headers to init
- Changed defaultSessionManager from private to internal to allow tests
- Add a test class to validate custom headers presence
