### PR TITLE
Change default values

### DIFF
--- a/Example/CocoaPods-AppStoreConnect-Swift-SDK/Tests/Endpoints/TestFlight/Beta Groups/CreateBetaGroupTests.swift
+++ b/Example/CocoaPods-AppStoreConnect-Swift-SDK/Tests/Endpoints/TestFlight/Beta Groups/CreateBetaGroupTests.swift
@@ -43,4 +43,29 @@ final class CreateBetaGroupTests: XCTestCase {
             betaTesterIds: betaTesterIds,
             buildIds: buildIds)))
     }
+    
+    func testURLRequestWithDefaultValues() {
+        let appId = "appId"
+        let name = "name"
+        
+        let endpoint = APIEndpoint.create(
+            betaGroupForAppWithId: appId,
+            name: name)
+        
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "POST")
+        
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups"
+        XCTAssertEqual(absoluteString, expected)
+        XCTAssertEqual(request?.httpBody, try? JSONEncoder().encode(BetaGroupCreateRequest(
+            appId: appId,
+            name: name,
+            publicLinkEnabled: nil,
+            publicLinkLimit: nil,
+            publicLinkLimitEnabled: nil,
+            betaTesterIds: [],
+            buildIds: [])))
+    }
+
 }

--- a/Sources/Endpoints/TestFlight/Beta Groups/CreateBetaGroup.swift
+++ b/Sources/Endpoints/TestFlight/Beta Groups/CreateBetaGroup.swift
@@ -26,8 +26,8 @@ extension APIEndpoint where T == BetaGroupResponse {
         publicLinkEnabled: Bool? = nil,
         publicLinkLimit: Int? = nil,
         publicLinkLimitEnabled: Bool? = nil,
-        betaTesterIds: [String]? = nil,
-        buildIds: [String]? = nil) -> APIEndpoint {
+        betaTesterIds: [String]? = [],
+        buildIds: [String]? = []) -> APIEndpoint {
         let request = BetaGroupCreateRequest(
             appId: appId,
             name: name,


### PR DESCRIPTION
Default values for betaTesterIds and buildIds must be empty arrays rather than nil, otherwise the API returns a 409 error on both fields.
