### PR TITLE
Fix Swift Package Manager installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Once you have your Swift package set up, adding the SDK as a dependency is as ea
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/AvdLee/appstoreconnect-swift-sdk.git")
+    .package(url: "https://github.com/AvdLee/appstoreconnect-swift-sdk.git", .upToNextMajor(from: "0.9.0"))
 ]
 ```
 


### PR DESCRIPTION
Currently, the instructions to use this library via Swift Package Manager result in a compiler error, as the initializer `Package.Dependency.package(url:)` does not exist.
This PR updates the instructions to use one of the available initializers.