### PR TITLE
Swift 5.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.1
+osx_image: xcode11.1
 gemfile: Gemfile
 bundler_args: "--without documentation --path bundle" # Don't download documentation for gems.
 cache:

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,13 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 
 import PackageDescription
 
 let package = Package(
     name: "AppStoreConnect-Swift-SDK",
+    platforms: [
+        .iOS(.v11),
+        .macOS(.v10_12),
+    ],
     products: [
         .library(
             name: "AppStoreConnect-Swift-SDK",

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "AppStoreConnect-Swift-SDK",
     platforms: [
         .iOS(.v11),
-        .macOS(.v10_12),
+        .macOS(.v10_12)
     ],
     products: [
         .library(


### PR DESCRIPTION
This PR updates the package description to use _swift-tools-version_ 5.1 and set the minimum version of both iOS and MacOS, in line with the deployment targets defined in https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/master/AppStoreConnect-Swift-SDK.podspec.
This fixes the compiler errors when trying to build with Swift 5.1.