### PR TITLE
Implemented Register a New Bundle ID endpoint

### DIFF
--- a/Sources/Endpoints/Provisioning/Bundle IDs/RegisterNewBundleID.swift
+++ b/Sources/Endpoints/Provisioning/Bundle IDs/RegisterNewBundleID.swift
@@ -1,0 +1,31 @@
+//
+//  RegisterNewBundleID.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Rui Costa on 07/12/2019.
+//
+
+import Foundation
+
+extension APIEndpoint where T == BundleIdResponse {
+    
+    /// Register a new bundle ID for app development.
+    public static func registerNewBundleId(
+        identifier: String,
+        name: String,
+        platform: BundleIdPlatform) -> APIEndpoint {
+        
+        let request = BundleIdCreateRequest(data: .init(
+            attributes: .init(
+            identifier: identifier,
+            name: name,
+            platform: platform,
+            seedId: nil)))
+        
+        return APIEndpoint(
+            path: "bundleIds",
+            method: .post,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request))
+    }
+}

--- a/Sources/Models/BundleIdCreateRequest.swift
+++ b/Sources/Models/BundleIdCreateRequest.swift
@@ -1,0 +1,29 @@
+//
+//  BundleIdCreateRequest.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Rui Costa on 07/12/2019.
+//
+
+/// A request containing a single resource.
+public struct BundleIdCreateRequest: Encodable {
+        
+    /// The resource data.
+    public let data: Data
+    
+    public struct Data: Encodable {
+        public let attributes: Attributes
+        public let type: String = "bundleIds"
+    }
+}
+
+// MARK: BundleIdCreateRequest.Data
+extension BundleIdCreateRequest.Data {
+    
+    public struct Attributes: Encodable {
+        public let identifier: String
+        public let name: String
+        public let platform: BundleIdPlatform
+        public let seedId: String?
+    }
+}

--- a/Sources/Models/BundleIdPlatform.swift
+++ b/Sources/Models/BundleIdPlatform.swift
@@ -1,0 +1,11 @@
+//
+//  BundleIdPlatform.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Rui Costa on 08/12/2019.
+//
+
+public enum BundleIdPlatform: String, Codable {
+    case iOS = "IOS"
+    case macOS = "MAC_OS"
+}

--- a/Sources/Models/BundleIdResponse.swift
+++ b/Sources/Models/BundleIdResponse.swift
@@ -1,0 +1,100 @@
+//
+//  BundleIdResponse.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Rui Costa on 07/12/2019.
+//
+
+import Foundation
+
+/// A response containing a single resource.
+public struct BundleIdResponse: Decodable {
+    
+    /// The resource data.
+    public let data: BundleId
+    
+    /// The data structure that represents the resource.
+    public struct BundleId: Decodable {
+        
+        /// The resource's attributes.
+        public let attributes: Attributes?
+        
+        /// The opaque resource ID that uniquely identifies the resource.
+        public let id: String
+        
+        /// Navigational links to related data and included resource types and IDs.
+        public let relationships: Relationships?
+        
+        /// The resource type.
+        public let type: String = "bundleIds"
+        
+        /// Navigational links that include the self-link.
+        public let links: ResourceLinks
+    }
+}
+
+// MARK: BundleIdResponse.BundleId
+extension BundleIdResponse.BundleId {
+    
+    public struct Attributes: Decodable {
+        public let identifier: String?
+        public let name: String?
+        public let platform: BundleIdPlatform?
+        public let seedId: String?
+    }
+    
+    public struct Relationships: Decodable {
+        public let profiles: Profiles
+        public let bundleIdCapabilities: BundleIdCapabilities
+    }
+    
+    public struct ResourceLinks: Decodable {
+        
+        /// The link to the resource.
+        public let `self`: URL
+    }
+}
+
+// MARK: BundleIdResponse.BundleId.Relationships
+extension BundleIdResponse.BundleId.Relationships {
+    
+    public struct Profiles: Decodable {
+        public let data: [Data]?
+        public let links: Links?
+        public let meta: PagingInformation?
+    }
+    
+    public struct BundleIdCapabilities: Decodable {
+        public let data: [Data]?
+        public let links: Links?
+        public let meta: PagingInformation?
+    }
+}
+
+// MARK: BundleIdResponse.BundleId.Relationships.Profiles
+extension BundleIdResponse.BundleId.Relationships.Profiles {
+    
+    public struct Data: Decodable {
+        public let id: String
+        public let type: String = "profiles"
+    }
+    
+    public struct Links: Decodable {
+        public let related: URL?
+        public let `self`: URL?
+    }
+}
+
+// MARK: BundleIdResponse.BundleId.Relationships.BundleIdCapabilities
+extension BundleIdResponse.BundleId.Relationships.BundleIdCapabilities {
+    
+    public struct Data: Decodable {
+        public let id: String
+        public let type: String = "bundleIdCapabilities"
+    }
+    
+    public struct Links: Decodable {
+        public let related: URL?
+        public let `self`: URL?
+    }
+}


### PR DESCRIPTION
This PR starts the structure for the Provisioning/Bundle IDs family of endpoints, including the full implementation of the `Register a New Bundle ID` endpoint.
As it's one of my first contributions, I tried to keep this PR simple and only implemented a single endpoint. If people are happy with the implementation and we're all aligned, I'm happy to carry on and implement the remaining Bundle ID endpoints to start with.