### PR TITLE
Make error messages more verbose when debugging

### DIFF
--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -37,12 +37,33 @@ public final class APIProvider {
 
     public typealias StatusCode = Int
 
-    public enum Error: Swift.Error {
+    public enum Error: Swift.Error, CustomDebugStringConvertible {
         case requestGeneration
         case unknownResponseType
         case requestFailure(StatusCode, Data?)
         case decodingError(Data)
         case requestExecutorError(Swift.Error)
+
+        public var debugDescription: String {
+            switch self {
+            case .requestGeneration:
+                return "Failed to generate request."
+            case .unknownResponseType:
+                return "Unknown response type."
+            case .requestFailure(let statusCode, let data):
+                if let data = data, let response = String(data: data, encoding: .utf8) {
+                    return "Request failed with status code \(statusCode) and response \(response))."
+                }
+                return "Request failed with status code \(statusCode)."
+            case .decodingError(let data):
+                if let error = String(data: data, encoding: .utf8) {
+                    return "Failed to decode data: \(error)."
+                }
+                return "Failed to decode data."
+            case .requestExecutorError(let error):
+                return "Failed to execute request \(error)."
+            }
+        }
     }
     
     /// Contains a JSON Decoder which can be reused.


### PR DESCRIPTION
When debugging some issues in my code, I noticed that the associated values of the error cases wouldn't be printed to console, making it harder to figure out what went wrong. Merging this improvement changes the `debugDescription` in order to better diagnose the associated value of type `Data` for example:
```diff
- requestFailure(401, Optional(350 bytes))
+ Request failed with status code 401 and response {
+	"errors": [{
+		"status": "401",
+		"code": "NOT_AUTHORIZED",
+		"title": "Authentication credentials are missing or invalid.",
+		"detail": "Provide a properly configured and signed bearer token, and make sure that it has not expired. Learn more about Generating Tokens for API Requests https://developer.apple.com/go/?id=api-generating-tokens"
+	}]
+ }
```