### PR TITLE
Add support for Certificates endpoints

### DIFF
--- a/Sources/Endpoints/Provisioning/Certificates/CreateCertificate.swift
+++ b/Sources/Endpoints/Provisioning/Certificates/CreateCertificate.swift
@@ -1,0 +1,32 @@
+//
+//  CreateCertificate.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/15/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == CertificateResponse {
+
+    /// Create a new certificate using a certificate signing request.
+    ///
+    /// - Parameters:
+    ///   - certificateType: (Required) The type of certificate to be created.
+    ///   - csrContent: (Required) The certificate signing request to be used to create the certificate.
+    public static func createCertificate(
+        withCertificateType certificateType: CertificateType,
+        csrContent: String) -> APIEndpoint {
+
+        let request = CertificateCreateRequest(data: .init(
+            attributes: .init(
+            certificateType: certificateType,
+            csrContent: csrContent)))
+
+        return APIEndpoint(
+            path: "certificates",
+            method: .post,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request))
+    }
+}

--- a/Sources/Endpoints/Provisioning/Certificates/ListDownloadCertificates.swift
+++ b/Sources/Endpoints/Provisioning/Certificates/ListDownloadCertificates.swift
@@ -1,0 +1,84 @@
+//
+//  ListDownloadCertificates.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/14/2019.
+//
+
+import Foundation
+
+extension APIEndpoint where T == CertificatesResponse {
+
+    /// Find and list certificates and download their data.
+    /// 
+    /// - Parameters:
+    ///   - fields: Fields to return for included related types.
+    ///   - filter: Attributes, relationships, and IDs by which to filter.
+    ///   - sort: Attributes by which to sort.
+    ///   - limit: Number of resources to return.
+    ///   - next: The next URL to use as a base. See `PagedDocumentLinks`.
+    public static func listDownloadCertificates(
+        fields: [Certificates.Field]? = nil,
+        filter: [Certificates.Filter]? = nil,
+        sort: [Certificates.Sort]? = nil,
+        limit: Int? = nil,
+        next: PagedDocumentLinks? = nil) -> APIEndpoint {
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+        if let filter = filter { parameters.add(filter) }
+        if let sort = sort { parameters.add(sort) }
+        if let limit = limit { parameters["limit"] = limit }
+        if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
+        return APIEndpoint(
+            path: "certificates",
+            method: .get,
+            parameters: parameters)
+    }
+}
+
+public struct Certificates {
+
+    public enum Field: String, CaseIterable, NestableQueryParameter {
+        case certificateContent, certificateType, csrContent, displayName, expirationDate, name, platform, serialNumber
+
+        static var key: String = "certificates"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    /// Attributes, relationships, and IDs by which to filter.
+    public enum Filter: NestableQueryParameter {
+        case id([String]), serialNumber([String]), certificateType(CertificateType), displayName([String])
+
+        static var key: String = "filter"
+        var pair: Pair {
+            switch self {
+            case .id(let value):
+                return ("id", value.joinedByCommas())
+            case .serialNumber(let value):
+                return ("serialNumber", value.joinedByCommas())
+            case .certificateType(let value):
+                return ("certificateType", value.rawValue)
+            case .displayName(let value):
+                return ("displayName", value.joinedByCommas())
+            }
+        }
+    }
+
+    /// Attributes by which to sort.
+    public enum Sort: String, CaseIterable, NestableQueryParameter {
+        case certificateTypeAscending = "+certificateType"
+        case certificateTypeDescending = "-certificateType"
+
+        case displayNameAscending = "+displayName"
+        case displayNameDescending = "-displayName"
+
+        case idAscending = "+id"
+        case idDescending = "-id"
+
+        case serialNumberAscending = "+serialNumber"
+        case serialNumberDescending = "-serialNumber"
+
+        static var key: String = "sort"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+}

--- a/Sources/Endpoints/Provisioning/Certificates/ReadDownloadCertificateInformation.swift
+++ b/Sources/Endpoints/Provisioning/Certificates/ReadDownloadCertificateInformation.swift
@@ -1,0 +1,27 @@
+//
+//  ReadDownloadCertificateInformation.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/14/2019.
+//
+
+import Foundation
+
+extension APIEndpoint where T == CertificateResponse {
+
+    /// Get information about a certificate and download the certificate data.
+    ///
+    /// - Parameters:
+    ///   - id: (Required) An opaque resource ID that uniquely identifies the certificate.
+    ///   - fields: Fields to return for included related types.
+    public static func readDownloadCertificate(
+        withId id: String,
+        fields: [Certificates.Field]? = nil) -> APIEndpoint {
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+        return APIEndpoint(
+            path: "certificates/\(id)",
+            method: .get,
+            parameters: parameters)
+    }
+}

--- a/Sources/Endpoints/Provisioning/Certificates/RevokeCertificate.swift
+++ b/Sources/Endpoints/Provisioning/Certificates/RevokeCertificate.swift
@@ -1,0 +1,22 @@
+//
+//  RevokeCertificate.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/15/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == Void {
+
+    /// Revoke a lost, stolen, compromised, or expiring signing certificate.
+    ///
+    /// - Parameters:
+    ///   - id: (Required) An opaque resource ID that uniquely identifies the certificate.
+    public static func revokeCertificate(withId id: String) -> APIEndpoint {
+        return APIEndpoint(
+            path: "certificates/\(id)",
+            method: .delete,
+            parameters: nil)
+    }
+}

--- a/Sources/Models/Certificate.swift
+++ b/Sources/Models/Certificate.swift
@@ -1,0 +1,35 @@
+//
+//  Certificate.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/14/19.
+//
+
+import Foundation
+
+/// The data structure that represents the resource.
+public struct Certificate: Codable {
+
+    /// The resource's attributes.
+    public let attributes: Certificate.Attributes
+
+    /// The opaque resource ID that uniquely identifies the resource.
+    public let id: String
+
+    /// The resource type.
+    public let type: String
+
+    /// Navigational links that include the self-link.
+    public let links: PagedDocumentLinks
+
+    /// Attributes that describe a certificate.
+    public struct Attributes: Codable {
+        public let certificateContent: String?
+        public let displayName: String?
+        public let expirationDate: Date?
+        public let name: String?
+        public let platform: BundleIdPlatform?
+        public let serialNumber: String?
+        public let certificateType: CertificateType?
+    }
+}

--- a/Sources/Models/CertificateCreateRequest.swift
+++ b/Sources/Models/CertificateCreateRequest.swift
@@ -1,0 +1,27 @@
+//
+//  CertificateCreateRequest.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/15/19.
+//
+
+/// A request containing a single resource.
+public struct CertificateCreateRequest: Encodable {
+
+    /// The resource data.
+    public let data: Data
+
+    public struct Data: Encodable {
+        public let attributes: Attributes
+        public let type: String = "certificates"
+    }
+}
+
+// MARK: CertificateCreateRequest.Data
+extension CertificateCreateRequest.Data {
+
+    public struct Attributes: Encodable {
+        public let certificateType: CertificateType
+        public let csrContent: String
+    }
+}

--- a/Sources/Models/CertificateResponse.swift
+++ b/Sources/Models/CertificateResponse.swift
@@ -1,0 +1,18 @@
+//
+//  CertificateResponse.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/15/19.
+//
+
+import Foundation
+
+/// A response containing a single resource.
+public struct CertificateResponse: Codable {
+
+    /// The resource data.
+    public let data: Certificate
+
+    /// Navigational links that include the self-link.
+    public let links: PagedDocumentLinks
+}

--- a/Sources/Models/CertificateType.swift
+++ b/Sources/Models/CertificateType.swift
@@ -1,0 +1,16 @@
+//
+//  CertificateType.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/14/19.
+//
+
+public enum CertificateType: String, Codable {
+    case iOSDevelopment = "IOS_DEVELOPMENT"
+    case iOSDistribution = "IOS_DISTRIBUTION"
+    case macAppDistribution = "MAC_APP_DISTRIBUTION"
+    case macInstallerDistribution = "MAC_INSTALLER_DISTRIBUTION"
+    case macAppDevelopment = "MAC_APP_DEVELOPMENT"
+    case developerIdKext = "DEVELOPER_ID_KEXT"
+    case developerIdApplication = "DEVELOPER_ID_APPLICATION"
+}

--- a/Sources/Models/CertificatesResponse.swift
+++ b/Sources/Models/CertificatesResponse.swift
@@ -1,0 +1,21 @@
+//
+//  CertificatesResponse.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/14/19.
+//
+
+import Foundation
+
+/// A response containing a list of resources.
+public struct CertificatesResponse: Codable {
+
+    /// The paging information details.
+    public let data: [Certificate]
+
+    /// Navigational links that include the self-link.
+    public let links: PagedDocumentLinks
+
+    /// Paging information.
+    public let meta: PagingInformation?
+}


### PR DESCRIPTION
I added support for all endpoints listed as part of the [Certificates](https://developer.apple.com/documentation/appstoreconnectapi/certificates) resource.

- aa006f0 implements https://developer.apple.com/documentation/appstoreconnectapi/list_and_download_certificates
- 63b8663 implements https://developer.apple.com/documentation/appstoreconnectapi/read_and_download_certificate_information
- 3b48d59 implements https://developer.apple.com/documentation/appstoreconnectapi/revoke_a_certificate
- eb225bd implements https://developer.apple.com/documentation/appstoreconnectapi/create_a_certificate

I followed the existing architecture and documentation style, but let me know if there's anything that should be done differently. 

This PR depends on https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/51 since the `BundleIdPlatform` type was already added there, I built on top of it, so it's probably going to fail on CI until we merge that.