### PR TITLE
Rename Certificates method name to align with API design

### DIFF
--- a/Sources/Endpoints/Provisioning/Certificates/CreateCertificate.swift
+++ b/Sources/Endpoints/Provisioning/Certificates/CreateCertificate.swift
@@ -14,8 +14,8 @@ extension APIEndpoint where T == CertificateResponse {
     /// - Parameters:
     ///   - certificateType: (Required) The type of certificate to be created.
     ///   - csrContent: (Required) The certificate signing request to be used to create the certificate.
-    public static func createCertificate(
-        withCertificateType certificateType: CertificateType,
+    public static func create(
+        certificateWithCertificateType certificateType: CertificateType,
         csrContent: String) -> APIEndpoint {
 
         let request = CertificateCreateRequest(data: .init(


### PR DESCRIPTION
I noticed that other methods such as https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/e6f8f3de57231fa1f7957261c59e392d5e79d5ab/Sources/Endpoints/TestFlight/Beta%20Groups/CreateBetaGroup.swift#L22 that create a resource use a different API naming, so I've changed the method added in #53 to conform to the same API design.

