### PR TITLE
typo fix for issue 42

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,3 +3,4 @@
 ### Next
 - Updated CI to make sure PR requests are reviewed using Danger.
 - Removed custom Result type.
+- Fixed typo for downloadSalesAndTrendsReports ([Issue 42](https://github.com/AvdLee/appstoreconnect-swift-sdk/issues/42))

--- a/Sources/Endpoints/Sales and Finance Reports/DownloadSalesAndTrendsReports.swift
+++ b/Sources/Endpoints/Sales and Finance Reports/DownloadSalesAndTrendsReports.swift
@@ -35,13 +35,13 @@ public enum DownloadSalesAndTrendsReports {
             case .frequency(let value):
                 return (Frequency.key, value.map({ $0.pair.value }).joinedByCommas())
             case .reportDate(let value):
-                return ("reportdate", value.joinedByCommas())
+                return ("reportDate", value.joinedByCommas())
             case .reportSubType(let value):
                 return (ReportSubType.key, value.map({ $0.pair.value }).joinedByCommas())
             case .reportType(let value):
                 return (ReportType.key, value.map({ $0.pair.value }).joinedByCommas())
             case .vendorNumber(let value):
-                return ("vendornumber", value.joinedByCommas())
+                return ("vendorNumber", value.joinedByCommas())
             case .version(let value):
                 return ("version", value.joinedByCommas())
             }


### PR DESCRIPTION
Typo fix for APIEndpoint.downloadSalesAndTrendsReports [Issue 42](https://github.com/AvdLee/appstoreconnect-swift-sdk/issues/42)