### PR TITLE
Fix SPM example project build

### DIFF
--- a/Example/SPM-AppStoreConnect-Swift-SDK/Package.swift
+++ b/Example/SPM-AppStoreConnect-Swift-SDK/Package.swift
@@ -4,6 +4,10 @@ import PackageDescription
 
 let package = Package(
     name: "SPM-AppStoreConnect-Swift-SDK",
+    platforms: [
+        .iOS(.v11),
+        .macOS(.v10_12)
+    ],
     dependencies: [
         .package(path: "../../")
     ],


### PR DESCRIPTION
The SPM example project fails to build with the following error since we don't specify a minimum macOS version.
```
Compiling for macOS 10.10, but module 'AppStoreConnect_Swift_SDK' has a minimum deployment target of macOS 10.12:
```

This PR fixes it! 🎉

Fixes #61 