### PR TITLE
Add support for Profiles and Devices endpoints

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@
 - Add support for all [Certificates](https://developer.apple.com/documentation/appstoreconnectapi/certificates) endpoints. (@BalestraPatrick)
 - Add support for all [Bundle ID](https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids) endpoints. (@ruipfcosta, @BalestraPatrick)
 - Add support for all [Bundle ID Capabilities](https://developer.apple.com/documentation/appstoreconnectapi/bundle_id_capabilities) endpoints. (@BalestraPatrick)
+- Add support for all [Profiles](https://developer.apple.com/documentation/appstoreconnectapi/profiles) endpoints. (@@BalestraPatrick)
+- Add support for all [Devices](https://developer.apple.com/documentation/appstoreconnectapi/devices) endpoints. (@BalestraPatrick)
 - Updated CI to make sure PR requests are reviewed using Danger. (@AvdLee)
 - Removed custom Result type. (@ruipfcosta)
 - Fixed typo for downloadSalesAndTrendsReports ([Issue 42](https://github.com/AvdLee/appstoreconnect-swift-sdk/issues/42))

--- a/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
+++ b/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
@@ -31,7 +31,7 @@ extension APIEndpoint where T == DevicesResponse {
     }
 }
 
-public struct Devices {
+public enum Devices {
 
     public enum Field: String, CaseIterable, NestableQueryParameter {
         case devices
@@ -83,7 +83,6 @@ public struct Devices {
     }
 }
 
-
 extension Devices.Field {
 
     public enum Devices: String, CaseIterable, NestableQueryParameter {
@@ -93,4 +92,3 @@ extension Devices.Field {
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
     }
 }
-

--- a/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
+++ b/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
@@ -14,14 +14,16 @@ extension APIEndpoint where T == DevicesResponse {
         fields: [Devices.Field]? = nil,
         filter: [Devices.Filter]? = nil,
         sort: [Devices.Sort]? = nil,
-        limit: Int? = nil) -> APIEndpoint {
+        limit: Int? = nil,
+        next: PagedDocumentLinks? = nil) -> APIEndpoint {
 
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let sort = sort { parameters.add(sort) }
         if let limit = limit { parameters["limit"] = limit }
-
+        if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
+        
         return APIEndpoint(
             path: "devices",
             method: .get,

--- a/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
+++ b/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
@@ -27,7 +27,7 @@ extension APIEndpoint where T == DevicesResponse {
         return APIEndpoint(
             path: "devices",
             method: .get,
-            parameters: nil)
+            parameters: parameters)
     }
 }
 

--- a/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
+++ b/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
@@ -1,0 +1,94 @@
+//
+//  ListDevices.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == DevicesResponse {
+
+    /// Find and list devices registered to your team.
+    public static func listDevices(
+        fields: [Devices.Field]? = nil,
+        filter: [Devices.Filter]? = nil,
+        sort: [Devices.Sort]? = nil,
+        limit: Int? = nil) -> APIEndpoint {
+
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+        if let filter = filter { parameters.add(filter) }
+        if let sort = sort { parameters.add(sort) }
+        if let limit = limit { parameters["limit"] = limit }
+
+        return APIEndpoint(
+            path: "devices",
+            method: .get,
+            parameters: nil)
+    }
+}
+
+public struct Devices {
+
+    public enum Field: String, CaseIterable, NestableQueryParameter {
+        case devices
+
+        static var key: String = "devices"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    /// Attributes, relationships, and IDs by which to filter.
+    public enum Filter: NestableQueryParameter {
+        case id([String]), name([String]), platform([Platform]), status([DeviceStatus]), udid([String])
+
+        static var key: String = "filter"
+        var pair: Pair {
+            switch self {
+            case .id(let values):
+                return ("id", values.joinedByCommas())
+            case .name(let values):
+                return ("name", values.joinedByCommas())
+            case .platform(let values):
+                return ("platform", values.map { $0.rawValue }.joinedByCommas())
+            case .status(let values):
+                return ("status", values.map { $0.rawValue }.joinedByCommas())
+            case .udid(let values):
+                return ("udid", values.joinedByCommas())
+            }
+        }
+    }
+
+    /// Attributes by which to sort.
+    public enum Sort: String, CaseIterable, NestableQueryParameter {
+        case idAscending = "+id"
+        case idDescending = "-id"
+
+        case nameAscending = "+name"
+        case nameDescending = "-name"
+
+        case platformAscending = "+platform"
+        case platformDescending = "-platform"
+
+        case statusAscending = "+status"
+        case statusDescending = "-status"
+
+        case udidAscending = "+udid"
+        case udidDescending = "-udid"
+
+        static var key: String = "sort"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+}
+
+
+extension Devices.Field {
+
+    public enum Devices: String, CaseIterable, NestableQueryParameter {
+        case addedDate, deviceClass, model, name, platform, status, udid
+
+        static var key: String = "devices"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+}
+

--- a/Sources/Endpoints/Provisioning/Devices/ModifyRegisteredDevice.swift
+++ b/Sources/Endpoints/Provisioning/Devices/ModifyRegisteredDevice.swift
@@ -1,0 +1,30 @@
+//
+//  ModifyRegisteredDevice.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == DeviceResponse {
+
+    /// Modify a capability for a bundle ID.
+    public static func modifyRegisteredDevice(
+        id: String,
+        name: String,
+        status: DeviceStatus) -> APIEndpoint {
+
+        let request = DeviceUpdateRequest(
+            id: id,
+            name: name,
+            status: status
+        )
+
+        return APIEndpoint(
+            path: "devices/\(id)",
+            method: .patch,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request))
+    }
+}

--- a/Sources/Endpoints/Provisioning/Devices/ReadDeviceInformation.swift
+++ b/Sources/Endpoints/Provisioning/Devices/ReadDeviceInformation.swift
@@ -1,0 +1,25 @@
+//
+//  ReadDeviceInformation.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == DeviceResponse {
+
+    /// Get information about a specific bundle ID.
+    public static func readDeviceInformation(
+        id: String,
+        fields: [Devices.Field]? = nil) -> APIEndpoint {
+
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+
+        return APIEndpoint(
+            path: "devices/\(id)",
+            method: .get,
+            parameters: parameters)
+    }
+}

--- a/Sources/Endpoints/Provisioning/Devices/RegisterNewDevice.swift
+++ b/Sources/Endpoints/Provisioning/Devices/RegisterNewDevice.swift
@@ -1,0 +1,30 @@
+//
+//  RegisterNewDevice.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == DeviceResponse {
+
+    /// Register a new device for app development.
+    public static func registerNewDevice(
+        name: String,
+        platform: Platform,
+        udid: String) -> APIEndpoint {
+
+        let request = DeviceCreateRequest(
+            name: name,
+            platform: platform,
+            udid: udid
+        )
+
+        return APIEndpoint(
+            path: "devices",
+            method: .post,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request))
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/CreateProfile.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/CreateProfile.swift
@@ -1,0 +1,34 @@
+//
+//  CreateProfile.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == ProfileResponse {
+
+    /// Create a new provisioning profile.
+    public static func create(
+        profileWithId id: String,
+        name: String,
+        profileType: ProfileType,
+        certificateIds: [String] = [],
+        deviceIds: [String] = []) -> APIEndpoint {
+
+        let request = ProfileCreateRequest(
+            id: id,
+            name: name,
+            profileType: profileType,
+            certificateIds: certificateIds,
+            deviceIds: deviceIds
+        )
+
+        return APIEndpoint(
+            path: "profiles",
+            method: .post,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request))
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/DeleteProfile.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/DeleteProfile.swift
@@ -1,0 +1,20 @@
+//
+//  DeleteProfile.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == Void {
+
+    /// Delete a provisioning profile that is used for app development or distribution.
+    public static func delete(profileWithId id: String) -> APIEndpoint {
+
+        return APIEndpoint(
+            path: "profiles/\(id)",
+            method: .delete,
+            parameters: nil)
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/GetAllCertificateIdsInProfile.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/GetAllCertificateIdsInProfile.swift
@@ -1,0 +1,25 @@
+//
+//  GetAllCertificateIdsInProfile.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == ProfileResponse {
+
+    /// Get the resource IDs of all certificates associated with a specific provisioning profile.
+    public static func getAllCertificates(
+        inProfileId id: String,
+        limit: Int? = nil) -> APIEndpoint {
+
+        var parameters = [String: Any]()
+        if let limit = limit { parameters["limit"] = limit }
+
+        return APIEndpoint(
+            path: "profiles/\(id)/relationships/certificates",
+            method: .get,
+            parameters: parameters)
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/GetAllDeviceResourceIdsInProfile.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/GetAllDeviceResourceIdsInProfile.swift
@@ -1,0 +1,25 @@
+//
+//  GetAllDeviceResourceIdsInProfile.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == ProfileDevicesLinkagesResponse {
+
+    /// Get the resource IDs of all devices associated with a specific provisioning profile.
+    public static func getAllDeviceIds(
+        inProfileId id: String,
+        limit: Int? = nil) -> APIEndpoint {
+
+        var parameters = [String: Any]()
+        if let limit = limit { parameters["limit"] = limit }
+
+        return APIEndpoint(
+            path: "profiles/\(id)/relationships/devices",
+            method: .get,
+            parameters: parameters)
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/GetBundleResourceIdInProfile.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/GetBundleResourceIdInProfile.swift
@@ -1,0 +1,21 @@
+//
+//  GetBundleResourceIdInProfile.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == ProfileBundleIdLinkageResponse {
+
+    /// Get the bundle ID information for a specific provisioning profile.
+    public static func getBundleResourceId(
+        inProfileId id: String) -> APIEndpoint {
+
+        return APIEndpoint(
+            path: "profiles/\(id)/relationships/bundleId",
+            method: .get,
+            parameters: nil)
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/ListAllCertificatesInProfile.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/ListAllCertificatesInProfile.swift
@@ -1,0 +1,25 @@
+//
+//  ListAllCertificatesInProfile.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == CertificatesResponse {
+
+    /// Get a list of all certificates and their data for a specific provisioning profile.
+    public static func listAllCertificates(
+        inProfileId id: String,
+        fields: [Profiles.Field]? = nil) -> APIEndpoint {
+
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+
+        return APIEndpoint(
+            path: "profiles/\(id)/certificates",
+            method: .get,
+            parameters: parameters)
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/ListAllDevicesInProfile.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/ListAllDevicesInProfile.swift
@@ -1,0 +1,27 @@
+//
+//  ListAllDevicesInProfile.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == DevicesResponse {
+
+    /// Get a list of all devices for a specific provisioning profile.
+    public static func listAllDevices(
+        inProfileId id: String,
+        fields: [Profiles.Field]? = nil,
+        limit: Int? = nil) -> APIEndpoint {
+
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+        if let limit = limit { parameters["limit"] = limit }
+
+        return APIEndpoint(
+            path: "profiles/\(id)/devices",
+            method: .get,
+            parameters: parameters)
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/ListDownloadProfiles.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/ListDownloadProfiles.swift
@@ -1,0 +1,157 @@
+//
+//  ListDownloadProfiles.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == ProfilesResponse {
+
+    /// Find and list provisioning profiles and download their data.
+    public static func listProfiles(
+        fields: [Profiles.Field]? = nil,
+        filter: [Profiles.Filter]? = nil,
+        include: [Profiles.Include]? = nil,
+        sort: [Profiles.Sort]? = nil,
+        limit: [Profiles.Limit]? = nil) -> APIEndpoint {
+
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+        if let filter = filter { parameters.add(filter) }
+        if let include = include { parameters.add(include) }
+        if let sort = sort { parameters.add(sort) }
+        if let limit = limit { parameters.add(limit) }
+
+        return APIEndpoint(
+            path: "profiles",
+            method: .get,
+            parameters: parameters)
+    }
+}
+
+public struct Profiles {
+
+    public enum Field: NestableQueryParameter {
+        case certificates([Certificates])
+        case devices([Devices])
+        case profiles([Profiles])
+        case bundleIds([BundleIds])
+
+        static var key: String = "fields"
+        var pair: Pair {
+            switch self {
+            case .certificates(let value):
+                return (Certificates.key, value.map({ $0.pair.value }).joinedByCommas())
+            case .devices(let value):
+                return (Devices.key, value.map({ $0.pair.value }).joinedByCommas())
+            case .profiles(let value):
+                return (Profiles.key, value.map({ $0.pair.value }).joinedByCommas())
+            case .bundleIds(let value):
+                return (BundleIds.key, value.map({ $0.pair.value }).joinedByCommas())
+            }
+        }
+    }
+
+    /// Attributes, relationships, and IDs by which to filter.
+    public enum Filter: NestableQueryParameter {
+        case id([String]), name([String]), profileState([ProfileState]), profileType([ProfileType])
+
+        static var key: String = "filter"
+        var pair: Pair {
+            switch self {
+            case .id(let values):
+                return ("id", values.joinedByCommas())
+            case .name(let values):
+                return ("name", values.joinedByCommas())
+            case .profileState(let values):
+                return ("profileState", values.map { $0.rawValue }.joinedByCommas())
+            case .profileType(let values):
+                return ("profileType", values.map { $0.rawValue }.joinedByCommas())
+            }
+        }
+    }
+
+    /// Relationship data to include in the response.
+    public enum Include: String, CaseIterable, NestableQueryParameter {
+        case bundleId, certificates, devices
+
+        static var key: String = "include"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    /// Attributes by which to sort.
+    public enum Sort: String, CaseIterable, NestableQueryParameter {
+        case idAscending = "+id"
+        case idDescending = "-id"
+
+        case nameAscending = "+name"
+        case nameDescending = "-name"
+
+        case profileStateAscending = "+profileState"
+        case profileStateDescending = "-profileState"
+
+        case profileTypeAscending = "+profileType"
+        case profileTypeDescending = "-profileType"
+
+        static var key: String = "sort"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    /// Number of included related resources to return.
+    public enum Limit: NestableQueryParameter {
+
+        /// Maximum: 200
+        case profiles(Int)
+
+        /// Maximum: 50
+        case certificates(Int)
+
+        /// Maximum: 50
+        case devices(Int)
+
+        static var key: String = "limit"
+        var pair: Pair {
+            switch self {
+            case .profiles(let value):
+                return (nil, "\(value)")
+            case .certificates(let value):
+                return ("certificates", "\(value)")
+            case .devices(let value):
+                return ("devices", "\(value)")
+            }
+        }
+    }
+}
+
+extension Profiles.Field {
+
+    public enum Certificates: String, CaseIterable, NestableQueryParameter {
+        case certificateContent, certificateType, csrContent, displayName, expirationDate, name, platform, serialNumber
+
+        static var key: String = "certificates"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    public enum Devices: String, CaseIterable, NestableQueryParameter {
+        case addedDate, deviceClass, model, name, platform, status, udid
+
+        static var key: String = "devices"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    public enum Profiles: String, CaseIterable, NestableQueryParameter {
+        case bundleId, certificates, createdDate, devices, expirationDate, name, platform, profileContent, profileState, profileType, uuid
+
+        static var key: String = "profiles"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    public enum BundleIds: String, CaseIterable, NestableQueryParameter {
+        case bundleIdCapabilities, identifier, name, platform, profiles, seedId
+
+        static var key: String = "bundleIds"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/ListDownloadProfiles.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/ListDownloadProfiles.swift
@@ -31,7 +31,7 @@ extension APIEndpoint where T == ProfilesResponse {
     }
 }
 
-public struct Profiles {
+public enum Profiles {
 
     public enum Field: NestableQueryParameter {
         case certificates([Certificates])

--- a/Sources/Endpoints/Provisioning/Profiles/ReadBundleIdInProfille.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/ReadBundleIdInProfille.swift
@@ -1,0 +1,25 @@
+//
+//  ReadBundleIdInProfille.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == BundleIdResponse {
+
+    /// Get the bundle ID information for a specific provisioning profile.
+    public static func readBundleId(
+        inProfileId id: String,
+        fields: [Profiles.Field]? = nil) -> APIEndpoint {
+
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+
+        return APIEndpoint(
+            path: "profiles/\(id)/bundleId",
+            method: .get,
+            parameters: parameters)
+    }
+}

--- a/Sources/Endpoints/Provisioning/Profiles/ReadDownloadProfileInformation.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/ReadDownloadProfileInformation.swift
@@ -1,0 +1,29 @@
+//
+//  ReadDownloadProfileInformation.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+extension APIEndpoint where T == ProfileResponse {
+
+    /// Get information about a specific bundle ID.
+    public static func readProfileInformation(
+        id: String,
+        fields: [Profiles.Field]? = nil,
+        include: [Profiles.Include]? = nil,
+        limit: [Profiles.Limit]? = nil) -> APIEndpoint {
+
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+        if let include = include { parameters.add(include) }
+        if let limit = limit { parameters.add(limit) }
+
+        return APIEndpoint(
+            path: "profiles/\(id)",
+            method: .get,
+            parameters: parameters)
+    }
+}

--- a/Sources/Models/Device.swift
+++ b/Sources/Models/Device.swift
@@ -1,0 +1,35 @@
+//
+//  Device.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+/// The data structure that represents the resource.
+public struct Device: Codable {
+
+    /// The resource's attributes.
+    public let attributes: Device.Attributes
+
+    /// The opaque resource ID that uniquely identifies the resource.
+    public let id: String
+
+    /// The resource type.
+    public let type: String = "devices"
+
+    /// Navigational links that include the self-link.
+    public let links: ResourceLinks<Device>
+
+    /// Attributes that describe a certificate.
+    public struct Attributes: Codable {
+        public let devicesClass: DeviceClass?
+        public let model: String?
+        public let name: String?
+        public let platform: BundleIdPlatform?
+        public let status: DeviceStatus?
+        public let udid: String?
+        public let addedDate: Date?
+    }
+}

--- a/Sources/Models/Device.swift
+++ b/Sources/Models/Device.swift
@@ -10,6 +10,17 @@ import Foundation
 /// The data structure that represents the resource.
 public struct Device: Codable {
 
+    /// Attributes that describe a certificate.
+    public struct Attributes: Codable {
+        public let devicesClass: DeviceClass?
+        public let model: String?
+        public let name: String?
+        public let platform: BundleIdPlatform?
+        public let status: DeviceStatus?
+        public let udid: String?
+        public let addedDate: Date?
+    }
+
     /// The resource's attributes.
     public let attributes: Device.Attributes
 
@@ -21,15 +32,4 @@ public struct Device: Codable {
 
     /// Navigational links that include the self-link.
     public let links: ResourceLinks<Device>
-
-    /// Attributes that describe a certificate.
-    public struct Attributes: Codable {
-        public let devicesClass: DeviceClass?
-        public let model: String?
-        public let name: String?
-        public let platform: BundleIdPlatform?
-        public let status: DeviceStatus?
-        public let udid: String?
-        public let addedDate: Date?
-    }
 }

--- a/Sources/Models/DeviceClass.swift
+++ b/Sources/Models/DeviceClass.swift
@@ -1,0 +1,17 @@
+//
+//  DeviceClass.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+public enum DeviceClass: String, Codable {
+    case appleWatch = "APPLE_WATCH"
+    case iPad = "IPAD"
+    case iPhone = "IPHONE"
+    case iPod = "IPOD"
+    case appleTv = "APPLE_TV"
+    case mac = "MAC"
+}

--- a/Sources/Models/DeviceCreateRequest.swift
+++ b/Sources/Models/DeviceCreateRequest.swift
@@ -1,0 +1,56 @@
+//
+//  DeviceCreateRequest.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+/// A request containing a single resource.
+public struct DeviceCreateRequest: Codable {
+
+    /// - Parameters:
+    ///   - name: The opaque resource ID that uniquely identifies the resource.
+    ///   - platform:
+    ///   - udid:
+    init(name: String,
+         platform: Platform,
+         udid: String) {
+        data = .init(
+            attributes: .init(
+                name: name,
+                platform: platform,
+                udid: udid
+            ))
+    }
+
+    /// The resource data.
+    public let data: DeviceCreateRequest.Data
+
+    public struct Data: Codable {
+
+        /// The resource's attributes.
+        public let attributes: DeviceCreateRequest.Data.Attributes
+
+        /// The resource type.Value: devices
+        public let type: String = "devices"
+    }
+}
+
+/// MARK: DeviceCreateRequest.Data
+extension DeviceCreateRequest.Data {
+
+    /// Attributes that describe a resource.
+    public struct Attributes: Codable {
+
+        ///
+        public let name: String?
+
+        ///
+        public let platform: Platform?
+
+        ///
+        public let udid: String?
+    }
+}

--- a/Sources/Models/DeviceCreateRequest.swift
+++ b/Sources/Models/DeviceCreateRequest.swift
@@ -10,6 +10,18 @@ import Foundation
 /// A request containing a single resource.
 public struct DeviceCreateRequest: Codable {
 
+    public struct Data: Codable {
+
+        /// The resource's attributes.
+        public let attributes: DeviceCreateRequest.Data.Attributes
+
+        /// The resource type.Value: devices
+        public let type: String = "devices"
+    }
+
+    /// The resource data.
+    public let data: DeviceCreateRequest.Data
+
     /// - Parameters:
     ///   - name: The opaque resource ID that uniquely identifies the resource.
     ///   - platform:
@@ -23,18 +35,6 @@ public struct DeviceCreateRequest: Codable {
                 platform: platform,
                 udid: udid
             ))
-    }
-
-    /// The resource data.
-    public let data: DeviceCreateRequest.Data
-
-    public struct Data: Codable {
-
-        /// The resource's attributes.
-        public let attributes: DeviceCreateRequest.Data.Attributes
-
-        /// The resource type.Value: devices
-        public let type: String = "devices"
     }
 }
 

--- a/Sources/Models/DeviceCreateRequest.swift
+++ b/Sources/Models/DeviceCreateRequest.swift
@@ -44,13 +44,13 @@ extension DeviceCreateRequest.Data {
     /// Attributes that describe a resource.
     public struct Attributes: Codable {
 
-        ///
+        /// The name of the device.
         public let name: String?
 
-        ///
+        /// The platform of the device.
         public let platform: Platform?
 
-        ///
+        /// The unique id of the device.
         public let udid: String?
     }
 }

--- a/Sources/Models/DeviceResponse.swift
+++ b/Sources/Models/DeviceResponse.swift
@@ -1,0 +1,18 @@
+//
+//  DeviceResponse.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+/// A response containing a single resource.
+public struct DeviceResponse: Codable {
+
+    /// The resource data.
+    public let data: Device
+
+    /// Navigational links that include the self-link.
+    public let links: DocumentLinks
+}

--- a/Sources/Models/DeviceStatus.swift
+++ b/Sources/Models/DeviceStatus.swift
@@ -1,0 +1,13 @@
+//
+//  DeviceStatus.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+public enum DeviceStatus: String, Codable {
+    case enabled = "ENABLED"
+    case disabled = "DISABLED"
+}

--- a/Sources/Models/DeviceUpdateRequest.swift
+++ b/Sources/Models/DeviceUpdateRequest.swift
@@ -12,8 +12,8 @@ public struct DeviceUpdateRequest: Codable {
 
     /// - Parameters:
     ///   - id: The opaque resource ID that uniquely identifies the resource.
-    ///   - name:
-    ///   - status:
+    ///   - name: The name of the device.
+    ///   - status: The status of the device.
     init(id: String,
          name: String,
          status: DeviceStatus) {
@@ -47,10 +47,10 @@ extension DeviceUpdateRequest.Data {
     /// Attributes that describe a resource.
     public struct Attributes: Codable {
 
-        ///
+        /// The name of the device.
         public let name: String?
 
-        ///
+        /// The status of the device.
         public let status: DeviceStatus?
     }
 }

--- a/Sources/Models/DeviceUpdateRequest.swift
+++ b/Sources/Models/DeviceUpdateRequest.swift
@@ -1,0 +1,56 @@
+//
+//  DeviceUpdateRequest.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+/// A request containing a single resource.
+public struct DeviceUpdateRequest: Codable {
+
+    /// - Parameters:
+    ///   - id: The opaque resource ID that uniquely identifies the resource.
+    ///   - name:
+    ///   - status:
+    init(id: String,
+         name: String,
+         status: DeviceStatus) {
+        data = .init(
+            attributes: .init(
+                name: name,
+                status: status
+            ),
+            id: id)
+    }
+
+    /// The object types and IDs of the related resources.
+    public let data: DeviceUpdateRequest.Data
+
+    public struct Data: Codable {
+
+        /// The resource's attributes.
+        public let attributes: DeviceUpdateRequest.Data.Attributes
+
+        /// The opaque resource ID that uniquely identifies the resource.
+        public let `id`: String
+
+        /// The resource type.Value: devices
+        public let type: String = "devices"
+    }
+}
+
+/// MARK: BundleIdCapabilityCreateRequest.Data
+extension DeviceUpdateRequest.Data {
+
+    /// Attributes that describe a resource.
+    public struct Attributes: Codable {
+
+        ///
+        public let name: String?
+
+        ///
+        public let status: DeviceStatus?
+    }
+}

--- a/Sources/Models/DeviceUpdateRequest.swift
+++ b/Sources/Models/DeviceUpdateRequest.swift
@@ -10,6 +10,21 @@ import Foundation
 /// A request containing a single resource.
 public struct DeviceUpdateRequest: Codable {
 
+    public struct Data: Codable {
+
+        /// The resource's attributes.
+        public let attributes: DeviceUpdateRequest.Data.Attributes
+
+        /// The opaque resource ID that uniquely identifies the resource.
+        public let `id`: String
+
+        /// The resource type.Value: devices
+        public let type: String = "devices"
+    }
+
+    /// The object types and IDs of the related resources.
+    public let data: DeviceUpdateRequest.Data
+
     /// - Parameters:
     ///   - id: The opaque resource ID that uniquely identifies the resource.
     ///   - name: The name of the device.
@@ -23,21 +38,6 @@ public struct DeviceUpdateRequest: Codable {
                 status: status
             ),
             id: id)
-    }
-
-    /// The object types and IDs of the related resources.
-    public let data: DeviceUpdateRequest.Data
-
-    public struct Data: Codable {
-
-        /// The resource's attributes.
-        public let attributes: DeviceUpdateRequest.Data.Attributes
-
-        /// The opaque resource ID that uniquely identifies the resource.
-        public let `id`: String
-
-        /// The resource type.Value: devices
-        public let type: String = "devices"
     }
 }
 

--- a/Sources/Models/DevicesResponse.swift
+++ b/Sources/Models/DevicesResponse.swift
@@ -1,0 +1,21 @@
+//
+//  DevicesResponse.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+/// A response containing a list of resources.
+public struct DevicesResponse: Codable {
+
+    /// The paging information details.
+    public let data: [Device]
+
+    /// Navigational links that include the self-link.
+    public let links: PagedDocumentLinks
+
+    /// Paging information.
+    public let meta: PagingInformation?
+}

--- a/Sources/Models/Profile.swift
+++ b/Sources/Models/Profile.swift
@@ -55,8 +55,8 @@ extension Profile.Relationships {
 
     public struct Certificates: Codable {
 
-        /// Profile.Relationships.Certificates.Data
-        public let data: Profile.Relationships.Certificates.Data?
+        /// [Profile.Relationships.Certificates.Data]
+        public let data: [Profile.Relationships.Certificates.Data]?
 
         /// Profile.Relationships.Certificates.Links
         public let links: Profile.Relationships.Certificates.Links?
@@ -79,8 +79,8 @@ extension Profile.Relationships {
 
     public struct BundleId: Codable {
 
-        /// [Profile.Relationships.BundleId.Data]
-        public let data: [Profile.Relationships.BundleId.Data]?
+        /// Profile.Relationships.BundleId.Data
+        public let data: Profile.Relationships.BundleId.Data?
 
         /// Profile.Relationships.BundleId.Links
         public let links: Profile.Relationships.BundleId.Links?

--- a/Sources/Models/ProfileBundleIdLinkageResponse.swift
+++ b/Sources/Models/ProfileBundleIdLinkageResponse.swift
@@ -10,12 +10,6 @@ import Foundation
 /// A response containing a list of related resource IDs.
 public struct ProfileBundleIdLinkageResponse: Codable {
 
-    /// The object types and IDs of the related resources.
-    public let data: [ProfileBundleIdLinkageResponse.Data]
-
-    /// Navigational links including the self-link and links to the related data.
-    public let links: DocumentLinks
-
     public struct Data: Codable {
 
         /// The opaque resource ID that uniquely identifies the resource.
@@ -24,4 +18,10 @@ public struct ProfileBundleIdLinkageResponse: Codable {
         /// The resource type.Value: bundleIds
         public let type: String = "bundleIds"
     }
+
+    /// The object types and IDs of the related resources.
+    public let data: [ProfileBundleIdLinkageResponse.Data]
+
+    /// Navigational links including the self-link and links to the related data.
+    public let links: DocumentLinks
 }

--- a/Sources/Models/ProfileBundleIdLinkageResponse.swift
+++ b/Sources/Models/ProfileBundleIdLinkageResponse.swift
@@ -1,0 +1,27 @@
+//
+//  ProfileBundleIdLinkageResponse.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/25/19.
+//
+
+import Foundation
+
+/// A response containing a list of related resource IDs.
+public struct ProfileBundleIdLinkageResponse: Codable {
+
+    /// The object types and IDs of the related resources.
+    public let data: [ProfileBundleIdLinkageResponse.Data]
+
+    /// Navigational links including the self-link and links to the related data.
+    public let links: DocumentLinks
+
+    public struct Data: Codable {
+
+        /// The opaque resource ID that uniquely identifies the resource.
+        public let `id`: String
+
+        /// The resource type.Value: bundleIds
+        public let type: String = "bundleIds"
+    }
+}

--- a/Sources/Models/ProfileCreateRequest.swift
+++ b/Sources/Models/ProfileCreateRequest.swift
@@ -1,0 +1,137 @@
+//
+//  ProfileCreateRequest.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/24/19.
+//
+
+import Foundation
+
+/// A request containing a single resource.
+public struct ProfileCreateRequest: Codable {
+
+    /// - Parameters:
+    ///   - id: The opaque resource ID that uniquely identifies the resource.
+    ///   - name:
+    ///   - profileType:
+    init(id: String,
+         name: String,
+         profileType: ProfileType,
+         certificateIds: [String] = [],
+         deviceIds: [String] = []) {
+
+        data = .init(
+            attributes: .init(
+                name: name,
+                profileType: profileType
+            ),
+            relationships: .init(
+                bundleId: .init(data: .init(id: id)),
+                certificates: .init(data: certificateIds.map { .init(id: $0) }),
+                devices: .init(data: deviceIds.map { .init(id: $0) })
+            )
+        )
+    }
+
+    /// The resource data.
+    public let data: ProfileCreateRequest.Data
+
+    public struct Data: Codable {
+
+        /// The resource's attributes.
+        public let attributes: ProfileCreateRequest.Data.Attributes
+
+        /// The types and IDs of the related data to update.
+        public let relationships: ProfileCreateRequest.Data.Relationships
+
+        /// The resource type.Value: profiles
+        public let type: String = "profiles"
+    }
+}
+
+/// MARK: ProfileCreateRequest.Data
+extension ProfileCreateRequest.Data {
+
+    /// Attributes that describe a resource.
+    public struct Attributes: Codable {
+
+        ///
+        public let name: String?
+
+        ///
+        public let profileType: ProfileType?
+    }
+
+    public struct Relationships: Codable {
+
+        /// ProfileCreateRequest.Data.Relationships.BundleId (Required)
+        public let bundleId: ProfileCreateRequest.Data.Relationships.BundleId
+
+        /// ProfileCreateRequest.Data.Relationships.Certificates (Required)
+        public let certificates: ProfileCreateRequest.Data.Relationships.Certificates
+
+        /// ProfileCreateRequest.Data.Relationships.Devices
+        public let devices: ProfileCreateRequest.Data.Relationships.Devices
+    }
+}
+
+/// MARK: ProfileCreateRequest.Data.Relationships
+extension ProfileCreateRequest.Data.Relationships {
+
+    public struct BundleId: Codable {
+
+        /// ProfileCreateRequest.Data.Relationships.BundleId.Data (Required)
+        public let data: ProfileCreateRequest.Data.Relationships.BundleId.Data
+    }
+
+    public struct Certificates: Codable {
+
+        /// ProfileCreateRequest.Data.Relationships.Certificates.Data (Required)
+        public let data: [ProfileCreateRequest.Data.Relationships.Certificates.Data]
+    }
+
+    public struct Devices: Codable {
+
+        /// ProfileCreateRequest.Data.Relationships.Devices.Data (Required)
+        public let data: [ProfileCreateRequest.Data.Relationships.Devices.Data]
+    }
+}
+
+/// MARK: ProfileCreateRequest.Data.Relationships.BundleId
+extension ProfileCreateRequest.Data.Relationships.BundleId {
+
+    public struct Data: Codable {
+
+        /// The opaque resource ID that uniquely identifies the resource.
+        public let `id`: String
+
+        /// The resource type.Value: apps
+        public let type: String = "bundleIds"
+    }
+}
+
+/// MARK: ProfileCreateRequest.Data.Relationships.Certificates
+extension ProfileCreateRequest.Data.Relationships.Certificates {
+
+    public struct Data: Codable {
+
+        /// The opaque resource ID that uniquely identifies the resource.
+        public let `id`: String
+
+        /// The resource type.Value: apps
+        public let type: String = "certificates"
+    }
+}
+
+/// MARK: ProfileCreateRequest.Data.Relationships.Devices
+extension ProfileCreateRequest.Data.Relationships.Devices {
+
+    public struct Data: Codable {
+
+        /// The opaque resource ID that uniquely identifies the resource.
+        public let `id`: String
+
+        /// The resource type.Value: apps
+        public let type: String = "devices"
+    }
+}

--- a/Sources/Models/ProfileCreateRequest.swift
+++ b/Sources/Models/ProfileCreateRequest.swift
@@ -10,6 +10,21 @@ import Foundation
 /// A request containing a single resource.
 public struct ProfileCreateRequest: Codable {
 
+    public struct Data: Codable {
+
+        /// The resource's attributes.
+        public let attributes: ProfileCreateRequest.Data.Attributes
+
+        /// The types and IDs of the related data to update.
+        public let relationships: ProfileCreateRequest.Data.Relationships
+
+        /// The resource type.Value: profiles
+        public let type: String = "profiles"
+    }
+
+    /// The resource data.
+    public let data: ProfileCreateRequest.Data
+
     /// - Parameters:
     ///   - id: The opaque resource ID that uniquely identifies the resource.
     ///   - name:
@@ -31,21 +46,6 @@ public struct ProfileCreateRequest: Codable {
                 devices: .init(data: deviceIds.map { .init(id: $0) })
             )
         )
-    }
-
-    /// The resource data.
-    public let data: ProfileCreateRequest.Data
-
-    public struct Data: Codable {
-
-        /// The resource's attributes.
-        public let attributes: ProfileCreateRequest.Data.Attributes
-
-        /// The types and IDs of the related data to update.
-        public let relationships: ProfileCreateRequest.Data.Relationships
-
-        /// The resource type.Value: profiles
-        public let type: String = "profiles"
     }
 }
 

--- a/Sources/Models/ProfileCreateRequest.swift
+++ b/Sources/Models/ProfileCreateRequest.swift
@@ -55,10 +55,10 @@ extension ProfileCreateRequest.Data {
     /// Attributes that describe a resource.
     public struct Attributes: Codable {
 
-        ///
+        /// The name of the profile.
         public let name: String?
 
-        ///
+        /// The type of the profile.
         public let profileType: ProfileType?
     }
 

--- a/Sources/Models/ProfileDevicesLinkagesResponse.swift
+++ b/Sources/Models/ProfileDevicesLinkagesResponse.swift
@@ -1,0 +1,30 @@
+//
+//  ProfileDevicesLinkagesResponse.swift
+//  AppStoreConnect-Swift-SDK
+//
+//  Created by Patrick Balestra on 12/26/19.
+//
+
+import Foundation
+
+/// A response containing a list of related resource IDs.
+public struct ProfileDevicesLinkagesResponse: Codable {
+
+    /// The object types and IDs of the related resources.
+    public let data: [ProfileDevicesLinkagesResponse.Data]
+
+    /// Navigational links including the self-link and links to the related data.
+    public let links: DocumentLinks
+
+    /// Paging information.
+    public let meta: PagingInformation?
+
+    public struct Data: Codable {
+
+        /// The opaque resource ID that uniquely identifies the resource.
+        public let `id`: String
+
+        /// The resource type.Value: devices
+        public let type: String = "devices"
+    }
+}

--- a/Sources/Models/ProfileDevicesLinkagesResponse.swift
+++ b/Sources/Models/ProfileDevicesLinkagesResponse.swift
@@ -10,15 +10,6 @@ import Foundation
 /// A response containing a list of related resource IDs.
 public struct ProfileDevicesLinkagesResponse: Codable {
 
-    /// The object types and IDs of the related resources.
-    public let data: [ProfileDevicesLinkagesResponse.Data]
-
-    /// Navigational links including the self-link and links to the related data.
-    public let links: DocumentLinks
-
-    /// Paging information.
-    public let meta: PagingInformation?
-
     public struct Data: Codable {
 
         /// The opaque resource ID that uniquely identifies the resource.
@@ -27,4 +18,13 @@ public struct ProfileDevicesLinkagesResponse: Codable {
         /// The resource type.Value: devices
         public let type: String = "devices"
     }
+
+    /// The object types and IDs of the related resources.
+    public let data: [ProfileDevicesLinkagesResponse.Data]
+
+    /// Navigational links including the self-link and links to the related data.
+    public let links: DocumentLinks
+
+    /// Paging information.
+    public let meta: PagingInformation?
 }


### PR DESCRIPTION
This PR implements all the [Profiles](https://developer.apple.com/documentation/appstoreconnectapi/profiles) and [Devices](https://developer.apple.com/documentation/appstoreconnectapi/devices) endpoints.

Feedback is welcome on the API design and everything. I tested most endpoints in a separate SPM project and everything seems to work for my use case.