### PR TITLE
Sometimes the bundle id has platform = "UNIVERSAL"

### DIFF
--- a/Sources/Models/BundleIdPlatform.swift
+++ b/Sources/Models/BundleIdPlatform.swift
@@ -8,4 +8,5 @@
 public enum BundleIdPlatform: String, Codable {
     case iOS = "IOS"
     case macOS = "MAC_OS"
+    case universal = "UNIVERSAL"    
 }


### PR DESCRIPTION
I received "UNIVERSAL" in a BundleIdsResponse, after a call to ListBundleIDs