### PR TITLE
Add public init to CapabilitySetting and CapabilityOption

### DIFF
--- a/Sources/Models/CapabilityOption.swift
+++ b/Sources/Models/CapabilityOption.swift
@@ -15,4 +15,20 @@ public struct CapabilityOption: Codable {
     public let key: CapabilityOptionKey?
     public let name: String?
     public let supportsWildcard: Bool?
+
+    public init(
+        description: String? = nil,
+        enabled: Bool? = nil,
+        enabledByDefault: Bool? = nil,
+        key: CapabilityOptionKey? = nil,
+        name: String? = nil,
+        supportsWildcard: Bool? = nil
+    ) {
+        self.description = description
+        self.enabled = enabled
+        self.enabledByDefault = enabledByDefault
+        self.key = key
+        self.name = name
+        self.supportsWildcard = supportsWildcard
+    }
 }

--- a/Sources/Models/CapabilitySetting.swift
+++ b/Sources/Models/CapabilitySetting.swift
@@ -17,4 +17,24 @@ public struct CapabilitySetting: Codable {
     public let options: [CapabilityOption]?
     public let visible: Bool?
     public let minInstances: Int?
+
+    public init(
+        allowedInstances: CapabilitySettingAllowedInstances? = nil,
+        description: String? = nil,
+        enabledByDefault: Bool? = nil,
+        key: CapabilitySettingKey? = nil,
+        name: String? = nil,
+        options: [CapabilityOption]? = nil,
+        visible: Bool? = nil,
+        minInstances: Int? = nil
+    ) {
+        self.allowedInstances = allowedInstances
+        self.description = description
+        self.enabledByDefault = enabledByDefault
+        self.key = key
+        self.name = name
+        self.options = options
+        self.visible = visible
+        self.minInstances = minInstances
+    }
 }


### PR DESCRIPTION
#### Background: 
`APIEndpoint.enableCapability` and `modifyCapability` function needs `CapabilitySetting`

Due to SPM restriction, struct doesn't have auto-generated init function. 
This PR is to create public init to CapabilityOptions and CapabilitySettings in order to init them outside the package. 