### PR TITLE
Add paging to listProfiles endpoint

### DIFF
--- a/Sources/Endpoints/Provisioning/Profiles/ListDownloadProfiles.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/ListDownloadProfiles.swift
@@ -15,7 +15,8 @@ extension APIEndpoint where T == ProfilesResponse {
         filter: [Profiles.Filter]? = nil,
         include: [Profiles.Include]? = nil,
         sort: [Profiles.Sort]? = nil,
-        limit: [Profiles.Limit]? = nil) -> APIEndpoint {
+        limit: [Profiles.Limit]? = nil,
+        next: PagedDocumentLinks? = nil) -> APIEndpoint {
 
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
@@ -23,6 +24,7 @@ extension APIEndpoint where T == ProfilesResponse {
         if let include = include { parameters.add(include) }
         if let sort = sort { parameters.add(sort) }
         if let limit = limit { parameters.add(limit) }
+        if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
 
         return APIEndpoint(
             path: "profiles",


### PR DESCRIPTION
APIEndpoint.listProfiles doesn't support paging for now.
This PR is to make `listProfiles` take `next` field to support pagination, like other list commands.