### PR TITLE
Add missing cases for ProfileState

### DIFF
--- a/AppStoreConnect-Swift-SDK.podspec
+++ b/AppStoreConnect-Swift-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppStoreConnect-Swift-SDK'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'The Swift SDK to work with the App Store Connect API from Apple.'
 
   s.description      = <<-DESC

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+### 1.1.1
+- Fix Prerelease Versions filter ([#98](https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/98)) via [@orj](https://github.com/orj)
+- Merge release 1.1.0 into master ([#97](https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/97)) via [@SwiftLeeBot](https://github.com/SwiftLeeBot)
+
 ### 1.1.0
 - Fix the parsing of Profile responses ([#95](https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/95)) via [@orj](https://github.com/orj)
 - Added missing build relationships ([#96](https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/96)) via [@Nafisa2020](https://github.com/Nafisa2020)


### PR DESCRIPTION
## Changes
Currently list Profile request will produce 
```
Cannot initialize ProfileState from invalid String value EXPIRED
```

This PR is to add the missing cases `EXPIRED` for `ProfileState `