### PR TITLE
More App Store Version Localization APIs/models.

### DIFF
--- a/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
+++ b/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
@@ -30,6 +30,12 @@
 		097063EE26296A020083B9DF /* AppScreenshotSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063ED26296A020083B9DF /* AppScreenshotSet.swift */; };
 		097063F026296CB50083B9DF /* AppScreenshotSetResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063EF26296CB50083B9DF /* AppScreenshotSetResponse.swift */; };
 		097063F226296ECD0083B9DF /* AppScreenshotSetsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063F126296ECD0083B9DF /* AppScreenshotSetsResponse.swift */; };
+		09D74D71263146CB003F6E5E /* ListAppScreenshotSetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D74D70263146CB003F6E5E /* ListAppScreenshotSetsTests.swift */; };
+		09D74D7726314A56003F6E5E /* ListAppPreviewSets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D74D7626314A56003F6E5E /* ListAppPreviewSets.swift */; };
+		09D74D7926314B2E003F6E5E /* CreateAppStoreVersionLocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D74D7826314B2E003F6E5E /* CreateAppStoreVersionLocalizationTests.swift */; };
+		09D74D7B26314C38003F6E5E /* DeleteAppStoreVersionLocalizationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D74D7A26314C38003F6E5E /* DeleteAppStoreVersionLocalizationsTests.swift */; };
+		09D74D7D26314CAE003F6E5E /* ReadAppStoreVersionLocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D74D7C26314CAD003F6E5E /* ReadAppStoreVersionLocalizationTests.swift */; };
+		09D74D7F26314D7C003F6E5E /* ModifyAppStoreVersionLocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D74D7E26314D7C003F6E5E /* ModifyAppStoreVersionLocalizationTests.swift */; };
 		3FE44F3B256FAF79008DD90C /* ListAppStoreVersionsForAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE44F3A256FAF79008DD90C /* ListAppStoreVersionsForAppTests.swift */; };
 		3FE44F41256FB602008DD90C /* ReadAppInfoOfAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE44F40256FB602008DD90C /* ReadAppInfoOfAppTests.swift */; };
 		3FE44F45256FC195008DD90C /* ListAppInfosForAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE44F44256FC195008DD90C /* ListAppInfosForAppTests.swift */; };
@@ -579,6 +585,12 @@
 		097063ED26296A020083B9DF /* AppScreenshotSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotSet.swift; sourceTree = "<group>"; };
 		097063EF26296CB50083B9DF /* AppScreenshotSetResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotSetResponse.swift; sourceTree = "<group>"; };
 		097063F126296ECD0083B9DF /* AppScreenshotSetsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotSetsResponse.swift; sourceTree = "<group>"; };
+		09D74D70263146CB003F6E5E /* ListAppScreenshotSetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppScreenshotSetsTests.swift; sourceTree = "<group>"; };
+		09D74D7626314A56003F6E5E /* ListAppPreviewSets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppPreviewSets.swift; sourceTree = "<group>"; };
+		09D74D7826314B2E003F6E5E /* CreateAppStoreVersionLocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersionLocalizationTests.swift; sourceTree = "<group>"; };
+		09D74D7A26314C38003F6E5E /* DeleteAppStoreVersionLocalizationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAppStoreVersionLocalizationsTests.swift; sourceTree = "<group>"; };
+		09D74D7C26314CAD003F6E5E /* ReadAppStoreVersionLocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAppStoreVersionLocalizationTests.swift; sourceTree = "<group>"; };
+		09D74D7E26314D7C003F6E5E /* ModifyAppStoreVersionLocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyAppStoreVersionLocalizationTests.swift; sourceTree = "<group>"; };
 		3FE44F3A256FAF79008DD90C /* ListAppStoreVersionsForAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppStoreVersionsForAppTests.swift; sourceTree = "<group>"; };
 		3FE44F40256FB602008DD90C /* ReadAppInfoOfAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAppInfoOfAppTests.swift; sourceTree = "<group>"; };
 		3FE44F44256FC195008DD90C /* ListAppInfosForAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppInfosForAppTests.swift; sourceTree = "<group>"; };
@@ -1204,6 +1216,35 @@
 			name = "Upload Operation";
 			sourceTree = "<group>";
 		};
+		09D74D7326314855003F6E5E /* Phased Releases */ = {
+			isa = PBXGroup;
+			children = (
+				F072FA1225C41BA30007F1BE /* GetAppStoreVersionPhasedReleaseTests.swift */,
+			);
+			name = "Phased Releases";
+			sourceTree = "<group>";
+		};
+		09D74D7426314860003F6E5E /* Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				09D74D7826314B2E003F6E5E /* CreateAppStoreVersionLocalizationTests.swift */,
+				09D74D7A26314C38003F6E5E /* DeleteAppStoreVersionLocalizationsTests.swift */,
+				F072FA2325C41C0F0007F1BE /* ListAppStoreVersionLocalizationsTests.swift */,
+				09D74D7C26314CAD003F6E5E /* ReadAppStoreVersionLocalizationTests.swift */,
+				09D74D7E26314D7C003F6E5E /* ModifyAppStoreVersionLocalizationTests.swift */,
+			);
+			name = Localizations;
+			sourceTree = "<group>";
+		};
+		09D74D7526314A30003F6E5E /* Previews */ = {
+			isa = PBXGroup;
+			children = (
+				09D74D7626314A56003F6E5E /* ListAppPreviewSets.swift */,
+				09D74D70263146CB003F6E5E /* ListAppScreenshotSetsTests.swift */,
+			);
+			name = Previews;
+			sourceTree = "<group>";
+		};
 		3FFAB2042529187E00DD78B2 /* AppInfo */ = {
 			isa = PBXGroup;
 			children = (
@@ -1543,8 +1584,9 @@
 		F072FA1125C41BA30007F1BE /* App Store Versions */ = {
 			isa = PBXGroup;
 			children = (
-				F072FA1225C41BA30007F1BE /* GetAppStoreVersionPhasedReleaseTests.swift */,
-				F072FA2325C41C0F0007F1BE /* ListAppStoreVersionLocalizationsTests.swift */,
+				09D74D7526314A30003F6E5E /* Previews */,
+				09D74D7426314860003F6E5E /* Localizations */,
+				09D74D7326314855003F6E5E /* Phased Releases */,
 			);
 			path = "App Store Versions";
 			sourceTree = "<group>";
@@ -2663,6 +2705,7 @@
 				50996ABB241500190044308C /* RemoveBetaTesterFromBetaGroupsTests.swift in Sources */,
 				50996B39241500190044308C /* BetaGroupRelationshipTests.swift in Sources */,
 				50996ACE241500190044308C /* AssignAppEncryptionDeclarationForBuildTests.swift in Sources */,
+				09D74D7B26314C38003F6E5E /* DeleteAppStoreVersionLocalizationsTests.swift in Sources */,
 				50996B2E241500190044308C /* ReplaceListOfVisibleAppsForUserTests.swift in Sources */,
 				50996B00241500190044308C /* ReadAppInformationOfBetaAppReviewDetailTests.swift in Sources */,
 				50996AE5241500190044308C /* ModifyBetaLicenseAgreementTests.swift in Sources */,
@@ -2675,6 +2718,7 @@
 				50996ACC241500190044308C /* ReadAppInformationOfAppEncryptionDeclaration.swift in Sources */,
 				50996B25241500190044308C /* DeleteBetaGroupTests.swift in Sources */,
 				50996AED241500190044308C /* ModifyBetaBuildLocalizationTests.swift in Sources */,
+				09D74D7926314B2E003F6E5E /* CreateAppStoreVersionLocalizationTests.swift in Sources */,
 				50996AFC241500190044308C /* ReadBetaAppLocalizationInformationTests.swift in Sources */,
 				50996AE0241500190044308C /* ReadAppInformationOfBuildTests.swift in Sources */,
 				50996AFA241500190044308C /* ReadAppInformationOfBetaAppLocalizationTests.swift in Sources */,
@@ -2725,8 +2769,10 @@
 				50996B1B241500190044308C /* ListBetaGroupsTests.swift in Sources */,
 				50996AD0241500190044308C /* ReadPrereleaseVersionOfBuildTests.swift in Sources */,
 				50996B0C241500190044308C /* GetBetaGroupIDsForAppTests.swift in Sources */,
+				09D74D7F26314D7C003F6E5E /* ModifyAppStoreVersionLocalizationTests.swift in Sources */,
 				3FE44F41256FB602008DD90C /* ReadAppInfoOfAppTests.swift in Sources */,
 				50996ABC241500190044308C /* ListAppsForBetaTesterTests.swift in Sources */,
+				09D74D7D26314CAE003F6E5E /* ReadAppStoreVersionLocalizationTests.swift in Sources */,
 				50996ACB241500190044308C /* GetAppResourceIDForAppEncryptionDeclarationTests.swift in Sources */,
 				50996B14241500190044308C /* GetBuildIDsOfAppTests.swift in Sources */,
 				50996AF5241500190044308C /* ModifyBuildBetaDetailTests.swift in Sources */,
@@ -2748,7 +2794,9 @@
 				50996B41241500190044308C /* QueryParameterTests.swift in Sources */,
 				50996B32241500190044308C /* ListAppsVisibleToInvitedUserTests.swift in Sources */,
 				50996B36241500190044308C /* DownloadFinanceReportsTests.swift in Sources */,
+				09D74D7726314A56003F6E5E /* ListAppPreviewSets.swift in Sources */,
 				50996B23241500190044308C /* CreateBetaGroupTests.swift in Sources */,
+				09D74D71263146CB003F6E5E /* ListAppScreenshotSetsTests.swift in Sources */,
 				50996AF0241500190044308C /* SendNotificationOfAvailableBuildTests.swift in Sources */,
 				50996B18241500190044308C /* ReadBetaGroupInformationTests.swift in Sources */,
 				3FE44F3B256FAF79008DD90C /* ListAppStoreVersionsForAppTests.swift in Sources */,

--- a/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
+++ b/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		092552A0262D6D7000D6119F /* ListAppPreviewSets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925529F262D6D7000D6119F /* ListAppPreviewSets.swift */; };
+		092552A3262D6EF000D6119F /* AppPreviewSetsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092552A2262D6EF000D6119F /* AppPreviewSetsResponse.swift */; };
+		092552A5262D6F1400D6119F /* AppPreviewSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092552A4262D6F1400D6119F /* AppPreviewSet.swift */; };
+		092552A7262D70B500D6119F /* AppPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092552A6262D70B500D6119F /* AppPreview.swift */; };
+		092552A9262D71E300D6119F /* AppPreviewResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092552A8262D71E300D6119F /* AppPreviewResponse.swift */; };
+		092552AB262D721600D6119F /* AppPreviewsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092552AA262D721600D6119F /* AppPreviewsResponse.swift */; };
 		097063C826294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063C726294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift */; };
 		097063CA26294BC70083B9DF /* ReadAppStoreVersionLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063C926294BC70083B9DF /* ReadAppStoreVersionLocalization.swift */; };
 		097063CE26294EE10083B9DF /* CreateAppStoreVersionLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063CD26294EE10083B9DF /* CreateAppStoreVersionLocalization.swift */; };
@@ -550,6 +556,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0925529F262D6D7000D6119F /* ListAppPreviewSets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppPreviewSets.swift; sourceTree = "<group>"; };
+		092552A2262D6EF000D6119F /* AppPreviewSetsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPreviewSetsResponse.swift; sourceTree = "<group>"; };
+		092552A4262D6F1400D6119F /* AppPreviewSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPreviewSet.swift; sourceTree = "<group>"; };
+		092552A6262D70B500D6119F /* AppPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPreview.swift; sourceTree = "<group>"; };
+		092552A8262D71E300D6119F /* AppPreviewResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPreviewResponse.swift; sourceTree = "<group>"; };
+		092552AA262D721600D6119F /* AppPreviewsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPreviewsResponse.swift; sourceTree = "<group>"; };
 		097063C726294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAppStoreVersionLocalizations.swift; sourceTree = "<group>"; };
 		097063C926294BC70083B9DF /* ReadAppStoreVersionLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAppStoreVersionLocalization.swift; sourceTree = "<group>"; };
 		097063CD26294EE10083B9DF /* CreateAppStoreVersionLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersionLocalization.swift; sourceTree = "<group>"; };
@@ -1107,6 +1119,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		092552A1262D6EDA00D6119F /* App Preview Sets */ = {
+			isa = PBXGroup;
+			children = (
+				092552A6262D70B500D6119F /* AppPreview.swift */,
+				092552A8262D71E300D6119F /* AppPreviewResponse.swift */,
+				092552A4262D6F1400D6119F /* AppPreviewSet.swift */,
+				092552A2262D6EF000D6119F /* AppPreviewSetsResponse.swift */,
+				092552AA262D721600D6119F /* AppPreviewsResponse.swift */,
+			);
+			name = "App Preview Sets";
+			sourceTree = "<group>";
+		};
 		097063D326295CEA0083B9DF /* App Store Version Localizations */ = {
 			isa = PBXGroup;
 			children = (
@@ -1140,12 +1164,13 @@
 			name = Localizations;
 			sourceTree = "<group>";
 		};
-		097063D92629604F0083B9DF /* Screenshot Sets */ = {
+		097063D92629604F0083B9DF /* Previews */ = {
 			isa = PBXGroup;
 			children = (
 				097063DA2629606B0083B9DF /* ListAppScreenshotSets.swift */,
+				0925529F262D6D7000D6119F /* ListAppPreviewSets.swift */,
 			);
-			name = "Screenshot Sets";
+			name = Previews;
 			sourceTree = "<group>";
 		};
 		097063DC2629607A0083B9DF /* App Screenshot Sets */ = {
@@ -1527,7 +1552,7 @@
 		F072FA1625C41BBA0007F1BE /* App Store Versions */ = {
 			isa = PBXGroup;
 			children = (
-				097063D92629604F0083B9DF /* Screenshot Sets */,
+				097063D92629604F0083B9DF /* Previews */,
 				097063D626295E410083B9DF /* Localizations */,
 				097063D426295E230083B9DF /* Phased Releases */,
 			);
@@ -1755,6 +1780,7 @@
 		OBJ_205 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				092552A1262D6EDA00D6119F /* App Preview Sets */,
 				097063E42629635E0083B9DF /* Upload Operation */,
 				097063E12629621D0083B9DF /* App Media State */,
 				097063DC2629607A0083B9DF /* App Screenshot Sets */,
@@ -2273,6 +2299,7 @@
 				097063D826295E740083B9DF /* ModifyAppStoreVersionLocalization.swift in Sources */,
 				OBJ_581 /* GetBundleResourceIdInProfile.swift in Sources */,
 				OBJ_582 /* ListAllCertificatesInProfile.swift in Sources */,
+				092552AB262D721600D6119F /* AppPreviewsResponse.swift in Sources */,
 				OBJ_583 /* ListAllDevicesInProfile.swift in Sources */,
 				OBJ_584 /* ListDownloadProfiles.swift in Sources */,
 				OBJ_585 /* ReadBundleIdInProfille.swift in Sources */,
@@ -2300,6 +2327,8 @@
 				OBJ_619 /* ReadAppInformationOfBetaAppReviewDetail.swift in Sources */,
 				OBJ_620 /* ReadBetaAppReviewDetailInformation.swift in Sources */,
 				OBJ_621 /* GetBuildIDForBetaAppReviewSubmission.swift in Sources */,
+				092552A3262D6EF000D6119F /* AppPreviewSetsResponse.swift in Sources */,
+				092552A9262D71E300D6119F /* AppPreviewResponse.swift in Sources */,
 				OBJ_622 /* ListBetaAppReviewSubmissions.swift in Sources */,
 				OBJ_623 /* ReadBetaAppReviewSubmissionInformation.swift in Sources */,
 				OBJ_624 /* ReadBuildInformationOfBetaAppReviewSubmission.swift in Sources */,
@@ -2498,11 +2527,13 @@
 				097063C826294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift in Sources */,
 				OBJ_793 /* BetaTesterRelationship.swift in Sources */,
 				097063E0262961EE0083B9DF /* AppMediaAssetState.swift in Sources */,
+				092552A7262D70B500D6119F /* AppPreview.swift in Sources */,
 				3FFAB21A2529190B00DD78B2 /* ListBetaAppLocalizationsOfApp.swift in Sources */,
 				OBJ_794 /* BetaTesterResponse.swift in Sources */,
 				OBJ_795 /* BetaTestersResponse.swift in Sources */,
 				OBJ_796 /* Build.swift in Sources */,
 				097063EC262965AD0083B9DF /* AppScreenshotsResponse.swift in Sources */,
+				092552A0262D6D7000D6119F /* ListAppPreviewSets.swift in Sources */,
 				OBJ_797 /* BuildAppEncryptionDeclarationLinkageRequest.swift in Sources */,
 				3FFAB1FD2529185600DD78B2 /* AppStoreVersion.swift in Sources */,
 				OBJ_798 /* BuildAppEncryptionDeclarationLinkageResponse.swift in Sources */,
@@ -2559,6 +2590,7 @@
 				3FFAB21C2529190B00DD78B2 /* ListBuildsOfApp.swift in Sources */,
 				OBJ_840 /* CertificateCreateRequest.swift in Sources */,
 				OBJ_841 /* CertificateResponse.swift in Sources */,
+				092552A5262D6F1400D6119F /* AppPreviewSet.swift in Sources */,
 				OBJ_842 /* CertificateType.swift in Sources */,
 				OBJ_843 /* CertificatesResponse.swift in Sources */,
 				OBJ_844 /* Device.swift in Sources */,

--- a/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
+++ b/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
@@ -7,6 +7,23 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		097063C826294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063C726294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift */; };
+		097063CA26294BC70083B9DF /* ReadAppStoreVersionLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063C926294BC70083B9DF /* ReadAppStoreVersionLocalization.swift */; };
+		097063CE26294EE10083B9DF /* CreateAppStoreVersionLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063CD26294EE10083B9DF /* CreateAppStoreVersionLocalization.swift */; };
+		097063D026294F4B0083B9DF /* AppStoreVersionLocalizationCreateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063CF26294F4B0083B9DF /* AppStoreVersionLocalizationCreateRequest.swift */; };
+		097063D226295CD90083B9DF /* AppStoreVersionLocalizationUpdateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063D126295CD90083B9DF /* AppStoreVersionLocalizationUpdateRequest.swift */; };
+		097063D826295E740083B9DF /* ModifyAppStoreVersionLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063D726295E740083B9DF /* ModifyAppStoreVersionLocalization.swift */; };
+		097063DB2629606B0083B9DF /* ListAppScreenshotSets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063DA2629606B0083B9DF /* ListAppScreenshotSets.swift */; };
+		097063DE262960BE0083B9DF /* AppScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063DD262960BE0083B9DF /* AppScreenshot.swift */; };
+		097063E0262961EE0083B9DF /* AppMediaAssetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063DF262961EE0083B9DF /* AppMediaAssetState.swift */; };
+		097063E3262962450083B9DF /* AppMediaStateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063E2262962450083B9DF /* AppMediaStateError.swift */; };
+		097063E62629636D0083B9DF /* UploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063E52629636D0083B9DF /* UploadOperation.swift */; };
+		097063E82629637F0083B9DF /* UploadOperationHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063E72629637F0083B9DF /* UploadOperationHeader.swift */; };
+		097063EA2629648D0083B9DF /* AppScreenshotResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063E92629648D0083B9DF /* AppScreenshotResponse.swift */; };
+		097063EC262965AD0083B9DF /* AppScreenshotsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063EB262965AD0083B9DF /* AppScreenshotsResponse.swift */; };
+		097063EE26296A020083B9DF /* AppScreenshotSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063ED26296A020083B9DF /* AppScreenshotSet.swift */; };
+		097063F026296CB50083B9DF /* AppScreenshotSetResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063EF26296CB50083B9DF /* AppScreenshotSetResponse.swift */; };
+		097063F226296ECD0083B9DF /* AppScreenshotSetsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097063F126296ECD0083B9DF /* AppScreenshotSetsResponse.swift */; };
 		3FE44F3B256FAF79008DD90C /* ListAppStoreVersionsForAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE44F3A256FAF79008DD90C /* ListAppStoreVersionsForAppTests.swift */; };
 		3FE44F41256FB602008DD90C /* ReadAppInfoOfAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE44F40256FB602008DD90C /* ReadAppInfoOfAppTests.swift */; };
 		3FE44F45256FC195008DD90C /* ListAppInfosForAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE44F44256FC195008DD90C /* ListAppInfosForAppTests.swift */; };
@@ -533,6 +550,23 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		097063C726294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAppStoreVersionLocalizations.swift; sourceTree = "<group>"; };
+		097063C926294BC70083B9DF /* ReadAppStoreVersionLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAppStoreVersionLocalization.swift; sourceTree = "<group>"; };
+		097063CD26294EE10083B9DF /* CreateAppStoreVersionLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersionLocalization.swift; sourceTree = "<group>"; };
+		097063CF26294F4B0083B9DF /* AppStoreVersionLocalizationCreateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreVersionLocalizationCreateRequest.swift; sourceTree = "<group>"; };
+		097063D126295CD90083B9DF /* AppStoreVersionLocalizationUpdateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreVersionLocalizationUpdateRequest.swift; sourceTree = "<group>"; };
+		097063D726295E740083B9DF /* ModifyAppStoreVersionLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyAppStoreVersionLocalization.swift; sourceTree = "<group>"; };
+		097063DA2629606B0083B9DF /* ListAppScreenshotSets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppScreenshotSets.swift; sourceTree = "<group>"; };
+		097063DD262960BE0083B9DF /* AppScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshot.swift; sourceTree = "<group>"; };
+		097063DF262961EE0083B9DF /* AppMediaAssetState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMediaAssetState.swift; sourceTree = "<group>"; };
+		097063E2262962450083B9DF /* AppMediaStateError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMediaStateError.swift; sourceTree = "<group>"; };
+		097063E52629636D0083B9DF /* UploadOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadOperation.swift; sourceTree = "<group>"; };
+		097063E72629637F0083B9DF /* UploadOperationHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadOperationHeader.swift; sourceTree = "<group>"; };
+		097063E92629648D0083B9DF /* AppScreenshotResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotResponse.swift; sourceTree = "<group>"; };
+		097063EB262965AD0083B9DF /* AppScreenshotsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotsResponse.swift; sourceTree = "<group>"; };
+		097063ED26296A020083B9DF /* AppScreenshotSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotSet.swift; sourceTree = "<group>"; };
+		097063EF26296CB50083B9DF /* AppScreenshotSetResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotSetResponse.swift; sourceTree = "<group>"; };
+		097063F126296ECD0083B9DF /* AppScreenshotSetsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScreenshotSetsResponse.swift; sourceTree = "<group>"; };
 		3FE44F3A256FAF79008DD90C /* ListAppStoreVersionsForAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppStoreVersionsForAppTests.swift; sourceTree = "<group>"; };
 		3FE44F40256FB602008DD90C /* ReadAppInfoOfAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadAppInfoOfAppTests.swift; sourceTree = "<group>"; };
 		3FE44F44256FC195008DD90C /* ListAppInfosForAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAppInfosForAppTests.swift; sourceTree = "<group>"; };
@@ -1073,6 +1107,78 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		097063D326295CEA0083B9DF /* App Store Version Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				F072FA0925C419300007F1BE /* AppStoreVersionLocalization.swift */,
+				097063CF26294F4B0083B9DF /* AppStoreVersionLocalizationCreateRequest.swift */,
+				F072FA0725C419300007F1BE /* AppStoreVersionLocalizationRelationship.swift */,
+				F072FA0A25C419300007F1BE /* AppStoreVersionLocalizationResponse.swift */,
+				F072FA0825C419300007F1BE /* AppStoreVersionLocalizationsResponse.swift */,
+				097063D126295CD90083B9DF /* AppStoreVersionLocalizationUpdateRequest.swift */,
+			);
+			name = "App Store Version Localizations";
+			sourceTree = "<group>";
+		};
+		097063D426295E230083B9DF /* Phased Releases */ = {
+			isa = PBXGroup;
+			children = (
+				F072FA1725C41BBA0007F1BE /* GetAppStoreVersionPhasedRelease.swift */,
+			);
+			name = "Phased Releases";
+			sourceTree = "<group>";
+		};
+		097063D626295E410083B9DF /* Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				097063CD26294EE10083B9DF /* CreateAppStoreVersionLocalization.swift */,
+				097063C726294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift */,
+				F072FA1825C41BBA0007F1BE /* ListAppStoreVersionLocalizations.swift */,
+				097063C926294BC70083B9DF /* ReadAppStoreVersionLocalization.swift */,
+				097063D726295E740083B9DF /* ModifyAppStoreVersionLocalization.swift */,
+			);
+			name = Localizations;
+			sourceTree = "<group>";
+		};
+		097063D92629604F0083B9DF /* Screenshot Sets */ = {
+			isa = PBXGroup;
+			children = (
+				097063DA2629606B0083B9DF /* ListAppScreenshotSets.swift */,
+			);
+			name = "Screenshot Sets";
+			sourceTree = "<group>";
+		};
+		097063DC2629607A0083B9DF /* App Screenshot Sets */ = {
+			isa = PBXGroup;
+			children = (
+				097063DD262960BE0083B9DF /* AppScreenshot.swift */,
+				097063E92629648D0083B9DF /* AppScreenshotResponse.swift */,
+				097063EB262965AD0083B9DF /* AppScreenshotsResponse.swift */,
+				097063ED26296A020083B9DF /* AppScreenshotSet.swift */,
+				097063EF26296CB50083B9DF /* AppScreenshotSetResponse.swift */,
+				097063F126296ECD0083B9DF /* AppScreenshotSetsResponse.swift */,
+			);
+			name = "App Screenshot Sets";
+			sourceTree = "<group>";
+		};
+		097063E12629621D0083B9DF /* App Media State */ = {
+			isa = PBXGroup;
+			children = (
+				097063DF262961EE0083B9DF /* AppMediaAssetState.swift */,
+				097063E2262962450083B9DF /* AppMediaStateError.swift */,
+			);
+			name = "App Media State";
+			sourceTree = "<group>";
+		};
+		097063E42629635E0083B9DF /* Upload Operation */ = {
+			isa = PBXGroup;
+			children = (
+				097063E52629636D0083B9DF /* UploadOperation.swift */,
+				097063E72629637F0083B9DF /* UploadOperationHeader.swift */,
+			);
+			name = "Upload Operation";
+			sourceTree = "<group>";
+		};
 		3FFAB2042529187E00DD78B2 /* AppInfo */ = {
 			isa = PBXGroup;
 			children = (
@@ -1421,8 +1527,9 @@
 		F072FA1625C41BBA0007F1BE /* App Store Versions */ = {
 			isa = PBXGroup;
 			children = (
-				F072FA1725C41BBA0007F1BE /* GetAppStoreVersionPhasedRelease.swift */,
-				F072FA1825C41BBA0007F1BE /* ListAppStoreVersionLocalizations.swift */,
+				097063D92629604F0083B9DF /* Screenshot Sets */,
+				097063D626295E410083B9DF /* Localizations */,
+				097063D426295E230083B9DF /* Phased Releases */,
 			);
 			path = "App Store Versions";
 			sourceTree = "<group>";
@@ -1648,6 +1755,10 @@
 		OBJ_205 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				097063E42629635E0083B9DF /* Upload Operation */,
+				097063E12629621D0083B9DF /* App Media State */,
+				097063DC2629607A0083B9DF /* App Screenshot Sets */,
+				097063D326295CEA0083B9DF /* App Store Version Localizations */,
 				OBJ_206 /* App.swift */,
 				OBJ_207 /* AppBetaAppLocalizationsLinkagesResponse.swift */,
 				OBJ_208 /* AppBetaAppReviewDetailLinkageResponse.swift */,
@@ -1671,16 +1782,11 @@
 				OBJ_222 /* AppsResponse.swift */,
 				3FFAB1F42529185600DD78B2 /* AppStoreAgeRating.swift */,
 				3FFAB1EF2529185600DD78B2 /* AppStoreVersion.swift */,
+				F072FA1C25C41BCD0007F1BE /* AppStoreVersionPhasedReleaseResponse.swift */,
 				3FFAB1F52529185600DD78B2 /* AppStoreVersionRelationship.swift */,
 				3FFAB1EC2529185600DD78B2 /* AppStoreVersionResponse.swift */,
 				3FFAB1F22529185600DD78B2 /* AppStoreVersionsResponse.swift */,
 				3FFAB1F02529185600DD78B2 /* AppStoreVersionState.swift */,
-				F072FA1C25C41BCD0007F1BE /* AppStoreVersionPhasedReleaseResponse.swift */,
-				F072FA1B25C41BCD0007F1BE /* PhasedReleaseState.swift */,
-				F072FA0725C419300007F1BE /* AppStoreVersionLocalizationRelationship.swift */,
-				F072FA0825C419300007F1BE /* AppStoreVersionLocalizationsResponse.swift */,
-				F072FA0925C419300007F1BE /* AppStoreVersionLocalization.swift */,
-				F072FA0A25C419300007F1BE /* AppStoreVersionLocalizationResponse.swift */,
 				OBJ_223 /* BetaAppLocalization.swift */,
 				OBJ_224 /* BetaAppLocalizationAppLinkageResponse.swift */,
 				OBJ_225 /* BetaAppLocalizationCreateRequest.swift */,
@@ -1799,6 +1905,7 @@
 				3FFAB1E82529185500DD78B2 /* KidsAgeBand.swift */,
 				OBJ_337 /* PagedDocumentLinks.swift */,
 				OBJ_338 /* PagingInformation.swift */,
+				F072FA1B25C41BCD0007F1BE /* PhasedReleaseState.swift */,
 				OBJ_339 /* Platform.swift */,
 				OBJ_342 /* PrereleaseVersion.swift */,
 				OBJ_343 /* PrereleaseVersionAppLinkageResponse.swift */,
@@ -2134,6 +2241,7 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_554 /* APIProvider.swift in Sources */,
+				097063E82629637F0083B9DF /* UploadOperationHeader.swift in Sources */,
 				OBJ_555 /* DefaultRequestExecutor.swift in Sources */,
 				OBJ_556 /* Endpoint.swift in Sources */,
 				OBJ_557 /* DisableCapability.swift in Sources */,
@@ -2146,6 +2254,7 @@
 				OBJ_564 /* ListAllProfileIdsForBundleId.swift in Sources */,
 				OBJ_565 /* ListBundleIds.swift in Sources */,
 				OBJ_566 /* ModifyBundleId.swift in Sources */,
+				097063DE262960BE0083B9DF /* AppScreenshot.swift in Sources */,
 				OBJ_567 /* ReadBundleIdInformation.swift in Sources */,
 				OBJ_568 /* RegisterNewBundleID.swift in Sources */,
 				OBJ_569 /* CreateCertificate.swift in Sources */,
@@ -2161,6 +2270,7 @@
 				OBJ_578 /* DeleteProfile.swift in Sources */,
 				OBJ_579 /* GetAllCertificateIdsInProfile.swift in Sources */,
 				OBJ_580 /* GetAllDeviceResourceIdsInProfile.swift in Sources */,
+				097063D826295E740083B9DF /* ModifyAppStoreVersionLocalization.swift in Sources */,
 				OBJ_581 /* GetBundleResourceIdInProfile.swift in Sources */,
 				OBJ_582 /* ListAllCertificatesInProfile.swift in Sources */,
 				OBJ_583 /* ListAllDevicesInProfile.swift in Sources */,
@@ -2169,11 +2279,13 @@
 				OBJ_586 /* ReadDownloadProfileInformation.swift in Sources */,
 				OBJ_587 /* DownloadFinanceReports.swift in Sources */,
 				OBJ_588 /* DownloadSalesAndTrendsReports.swift in Sources */,
+				097063EE26296A020083B9DF /* AppScreenshotSet.swift in Sources */,
 				OBJ_589 /* AssignBuildsToAppEncryptionDeclaration.swift in Sources */,
 				OBJ_590 /* GetAppResourceIDForAppEncryptionDeclaration.swift in Sources */,
 				OBJ_591 /* ListAppEncryptionDeclarations.swift in Sources */,
 				OBJ_592 /* ReadAppEncryptionDeclarationInformation.swift in Sources */,
 				OBJ_593 /* ReadAppInformationOfAppEncryptionDeclaration.swift in Sources */,
+				097063E62629636D0083B9DF /* UploadOperation.swift in Sources */,
 				3FFAB1F92529185600DD78B2 /* AppInfoRelationship.swift in Sources */,
 				OBJ_609 /* CreateBetaAppLocalization.swift in Sources */,
 				OBJ_610 /* DeleteBetaAppLocalization.swift in Sources */,
@@ -2194,11 +2306,13 @@
 				OBJ_625 /* SubmitAppForBetaReview.swift in Sources */,
 				OBJ_626 /* CreateBetaBuildLocalization.swift in Sources */,
 				OBJ_627 /* DeleteBetaBuildLocalization.swift in Sources */,
+				097063E3262962450083B9DF /* AppMediaStateError.swift in Sources */,
 				F072FA1A25C41BBA0007F1BE /* ListAppStoreVersionLocalizations.swift in Sources */,
 				OBJ_628 /* GetBuildIDForBetaBuildLocalization.swift in Sources */,
 				3FFAB2032529185600DD78B2 /* AppStoreVersionRelationship.swift in Sources */,
 				OBJ_629 /* ListBetaBuildLocalizations.swift in Sources */,
 				OBJ_630 /* ModifyBetaBuildLocalization.swift in Sources */,
+				097063CE26294EE10083B9DF /* CreateAppStoreVersionLocalization.swift in Sources */,
 				OBJ_631 /* ReadBetaBuildLocalizationInformation.swift in Sources */,
 				OBJ_632 /* ReadBuildInformationOfBetaBuildLocalization.swift in Sources */,
 				OBJ_633 /* AddBetaTestersToBetaGroup.swift in Sources */,
@@ -2226,6 +2340,7 @@
 				OBJ_653 /* SendInvitationToBetaTester.swift in Sources */,
 				OBJ_654 /* AddBetaTesterToBetaGroups.swift in Sources */,
 				3FFAB1F62529185600DD78B2 /* KidsAgeBand.swift in Sources */,
+				097063EA2629648D0083B9DF /* AppScreenshotResponse.swift in Sources */,
 				OBJ_655 /* AssignBetaTesterToBuilds.swift in Sources */,
 				OBJ_656 /* CreateBetaTester.swift in Sources */,
 				OBJ_657 /* DeleteBetaTester.swift in Sources */,
@@ -2238,6 +2353,7 @@
 				OBJ_663 /* ListBetaGroupsToWhichBetaTesterBelongs.swift in Sources */,
 				OBJ_664 /* ListBetaTesters.swift in Sources */,
 				OBJ_665 /* ListBuildsAssignedToBetaTester.swift in Sources */,
+				097063F226296ECD0083B9DF /* AppScreenshotSetsResponse.swift in Sources */,
 				OBJ_666 /* RemoveBetaTesterAccessToApps.swift in Sources */,
 				3FFAB1FA2529185600DD78B2 /* AppStoreVersionResponse.swift in Sources */,
 				OBJ_667 /* RemoveBetaTesterFromBetaGroups.swift in Sources */,
@@ -2371,17 +2487,22 @@
 				OBJ_784 /* BetaTesterAppsLinkagesResponse.swift in Sources */,
 				OBJ_785 /* BetaTesterBetaGroupsLinkagesRequest.swift in Sources */,
 				OBJ_786 /* BetaTesterBetaGroupsLinkagesResponse.swift in Sources */,
+				097063D026294F4B0083B9DF /* AppStoreVersionLocalizationCreateRequest.swift in Sources */,
 				OBJ_787 /* BetaTesterBuildsLinkagesRequest.swift in Sources */,
 				OBJ_788 /* BetaTesterBuildsLinkagesResponse.swift in Sources */,
+				097063D226295CD90083B9DF /* AppStoreVersionLocalizationUpdateRequest.swift in Sources */,
 				OBJ_789 /* BetaTesterCreateRequest.swift in Sources */,
 				OBJ_790 /* BetaTesterInvitation.swift in Sources */,
 				OBJ_791 /* BetaTesterInvitationCreateRequest.swift in Sources */,
 				OBJ_792 /* BetaTesterInvitationResponse.swift in Sources */,
+				097063C826294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift in Sources */,
 				OBJ_793 /* BetaTesterRelationship.swift in Sources */,
+				097063E0262961EE0083B9DF /* AppMediaAssetState.swift in Sources */,
 				3FFAB21A2529190B00DD78B2 /* ListBetaAppLocalizationsOfApp.swift in Sources */,
 				OBJ_794 /* BetaTesterResponse.swift in Sources */,
 				OBJ_795 /* BetaTestersResponse.swift in Sources */,
 				OBJ_796 /* Build.swift in Sources */,
+				097063EC262965AD0083B9DF /* AppScreenshotsResponse.swift in Sources */,
 				OBJ_797 /* BuildAppEncryptionDeclarationLinkageRequest.swift in Sources */,
 				3FFAB1FD2529185600DD78B2 /* AppStoreVersion.swift in Sources */,
 				OBJ_798 /* BuildAppEncryptionDeclarationLinkageResponse.swift in Sources */,
@@ -2419,10 +2540,12 @@
 				OBJ_825 /* BundleIdCapabilityUpdateRequest.swift in Sources */,
 				3FFAB2022529185600DD78B2 /* AppStoreAgeRating.swift in Sources */,
 				OBJ_826 /* BundleIdCreateRequest.swift in Sources */,
+				097063F026296CB50083B9DF /* AppScreenshotSetResponse.swift in Sources */,
 				OBJ_827 /* BundleIdPlatform.swift in Sources */,
 				OBJ_828 /* BundleIdProfilesLinkagesResponse.swift in Sources */,
 				OBJ_829 /* BundleIdRelationship.swift in Sources */,
 				OBJ_830 /* BundleIdResponse.swift in Sources */,
+				097063CA26294BC70083B9DF /* ReadAppStoreVersionLocalization.swift in Sources */,
 				OBJ_831 /* BundleIdUpdateRequest.swift in Sources */,
 				OBJ_832 /* BundleIdsResponse.swift in Sources */,
 				3FFAB21E2529190B00DD78B2 /* RemoveBetaTestersFromGroupsAndBuildsOfApp.swift in Sources */,
@@ -2482,6 +2605,7 @@
 				OBJ_876 /* UserInvitationCreateRequest.swift in Sources */,
 				OBJ_877 /* UserInvitationResponse.swift in Sources */,
 				OBJ_878 /* UserInvitationVisibleAppsLinkagesResponse.swift in Sources */,
+				097063DB2629606B0083B9DF /* ListAppScreenshotSets.swift in Sources */,
 				OBJ_879 /* UserInvitationsResponse.swift in Sources */,
 				OBJ_880 /* UserResponse.swift in Sources */,
 				OBJ_881 /* UserRole.swift in Sources */,

--- a/AppStoreConnect-Swift-SDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/AppStoreConnect-Swift-SDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersionLocalization.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersionLocalization.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public extension APIEndpoint where T == AppStoreVersionLocalizationResponse {
+    static func create(
+        appStoreVersionLocalizationForVersionWithId versionId: String,
+        locale: String,
+        description: String? = nil,
+        keywords: String? = nil,
+        marketingUrl: String? = nil,
+        promotionalText: String? = nil,
+        supportUrl: String? = nil,
+        whatsNew: String? = nil
+    ) -> APIEndpoint {
+        let request = AppStoreVersionLocalizationCreateRequest(
+            appStoreVersionId: versionId,
+            locale: locale,
+            description: description,
+            keywords: keywords,
+            marketingUrl: marketingUrl,
+            promotionalText: promotionalText,
+            supportUrl: supportUrl,
+            whatsNew: whatsNew
+        )
+        return APIEndpoint(
+            path: "appStoreVersionLocalizations",
+            method: .post,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request)
+        )
+    }
+}

--- a/Sources/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersionLocalization.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersionLocalization.swift
@@ -6,9 +6,9 @@ public extension APIEndpoint where T == AppStoreVersionLocalizationResponse {
         locale: String,
         description: String? = nil,
         keywords: String? = nil,
-        marketingUrl: String? = nil,
+        marketingUrl: URL? = nil,
         promotionalText: String? = nil,
-        supportUrl: String? = nil,
+        supportUrl: URL? = nil,
         whatsNew: String? = nil
     ) -> APIEndpoint {
         let request = AppStoreVersionLocalizationCreateRequest(

--- a/Sources/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersionLocalizations.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersionLocalizations.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public extension APIEndpoint where T == Void {
+    static func delete(appStoreVersionLocalizationWithId id: String) -> APIEndpoint {
+        return APIEndpoint(path: "appStoreVersionLocalizations/\(id)", method: .delete, parameters: nil)
+    }
+}

--- a/Sources/Endpoints/TestFlight/App Store Versions/ListAppPreviewSets.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/ListAppPreviewSets.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+public extension APIEndpoint where T == AppPreviewSetsResponse {
+    static func appPreviewSets(
+        forAppStoreVersionLocalization id: String,
+        fields: [ListAppPreviewSetsForAppStoreVersionLocalization.Field]? = nil,
+        includes: [ListAppPreviewSetsForAppStoreVersionLocalization.Include]? = nil,
+        limit: Int? = nil
+    ) -> APIEndpoint {
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+        if let includes = includes { parameters.add(includes) }
+        if let limit = limit { parameters["limit"] = limit }
+        return APIEndpoint(
+            path: "appStoreVersions/\(id)/appPreviewSets",
+            method: .get,
+            parameters: parameters
+        )
+    }
+}
+
+public enum ListAppPreviewSetsForAppStoreVersionLocalization {
+    public enum Field: NestableQueryParameter {
+        case appPreviewSets([AppPreviewSets])
+        case appPreviews([AppPreviews])
+        case appStoreVersionLocalizations([AppStoreVersionLocalizations])
+        case previewType([PreviewType])
+
+        static var key: String = "fields"
+        var pair: Pair {
+            switch self {
+            case let .appPreviewSets(value):
+                return (AppPreviewSets.key, value.map { $0.pair.value }.joinedByCommas())
+
+            case let .appPreviews(value):
+                return (AppPreviews.key, value.map { $0.pair.value }.joinedByCommas())
+
+            case let .appStoreVersionLocalizations(value):
+                return (AppStoreVersionLocalizations.key, value.map { $0.pair.value }.joinedByCommas())
+
+            case let .previewType(value):
+                return (PreviewType.key, value.map { $0.pair.value }.joinedByCommas())
+            }
+        }
+    }
+
+    public enum Include: String, CaseIterable, NestableQueryParameter {
+        case appPreviews, appStoreVersionLocalization
+
+        static var key: String = "include"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+}
+
+public extension ListAppPreviewSetsForAppStoreVersionLocalization.Field {
+    enum AppPreviewSets: String, CaseIterable, NestableQueryParameter {
+        case appPreviews, appStoreVersionLocalization, previewType
+
+        static var key: String = "appPreviewSets"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    enum AppPreviews: String, CaseIterable, NestableQueryParameter {
+        case appPreviewSet, assetDeliveryState, fileName, fileSize, mimeType, previewFrameTimeCode, previewImage,
+             sourceFileChecksum, uploadOperations, uploaded, videoUrl
+
+        static var key: String = "appPreviews"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    enum AppStoreVersionLocalizations: String, CaseIterable, NestableQueryParameter {
+        case appPreviewSets, appScreenshotSets, appStoreVersion, description, keywords, locale, marketingUrl,
+             promotionalText, supportUrl, whatsNew
+
+        static var key: String = "appStoreVersionLocalizations"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    enum PreviewType: String, CaseIterable, NestableQueryParameter {
+        case iPhone6Point5Inch = "IPHONE_65"
+        case iPhone5Point8Inch = "IPHONE_58"
+        case iPhone5Point5Inch = "IPHONE_55"
+        case iPhone4Point7Inch = "IPHONE_47"
+        case iPhone4Inch = "IPHONE_40"
+        case iPhone3Point5Inch = "IPHONE_35"
+        case iPadPro3rdGen12Point9Inch = "IPAD_PRO_3GEN_129"
+        case iPadPro3rdGen11Inch = "IPAD_PRO_3GEN_11"
+        case iPadPro12Point9Inch = "IPAD_PRO_129"
+        case iPadPro10Point5Inch = "IPAD_105"
+        case iPadPro9Point7Inch = "IPAD_97"
+        case mac = "DESKTOP"
+        case appleWatchSeries4 = "WATCH_SERIES_4"
+        case appleWatchSeries3 = "WATCH_SERIES_3"
+        case appleTV = "APPLE_TV"
+
+        static var key: String = "previewType"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+}

--- a/Sources/Endpoints/TestFlight/App Store Versions/ListAppScreenshotSets.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/ListAppScreenshotSets.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+public extension APIEndpoint where T == AppScreenshotSetsResponse {
+    static func appScreenshotSets(
+        forAppStoreVersionLocalization id: String,
+        fields: [ListAppScreenshotSetsForAppStoreVersionLocalization.Field]? = nil,
+        includes: [ListAppScreenshotSetsForAppStoreVersionLocalization.Include]? = nil,
+        limit: Int? = nil
+    ) -> APIEndpoint {
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+        if let includes = includes { parameters.add(includes) }
+        if let limit = limit { parameters["limit"] = limit }
+        return APIEndpoint(
+            path: "appStoreVersions/\(id)/appScreenshotSets",
+            method: .get,
+            parameters: parameters
+        )
+    }
+}
+
+public enum ListAppScreenshotSetsForAppStoreVersionLocalization {
+    public enum Field: NestableQueryParameter {
+        case appScreenshotSets([AppScreenshotSets])
+        case appScreenshots([AppScreenshots])
+        case appStoreVersionLocalizations([AppStoreVersionLocalizations])
+        case screenshotDisplayType([ScreenshotDisplayType])
+
+        static var key: String = "fields"
+        var pair: Pair {
+            switch self {
+            case let .appScreenshotSets(value):
+                return (AppScreenshotSets.key, value.map { $0.pair.value }.joinedByCommas())
+
+            case let .appScreenshots(value):
+                return (AppScreenshots.key, value.map { $0.pair.value }.joinedByCommas())
+
+            case let .appStoreVersionLocalizations(value):
+                return (AppStoreVersionLocalizations.key, value.map { $0.pair.value }.joinedByCommas())
+
+            case let .screenshotDisplayType(value):
+                return (ScreenshotDisplayType.key, value.map { $0.pair.value }.joinedByCommas())
+            }
+        }
+    }
+
+    public enum Include: String, CaseIterable, NestableQueryParameter {
+        case appScreenshots, appStoreVersionLocalization
+
+        static var key: String = "include"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+}
+
+public extension ListAppScreenshotSetsForAppStoreVersionLocalization.Field {
+    enum AppScreenshotSets: String, CaseIterable, NestableQueryParameter {
+        case appScreenshots, appStoreVersionLocalization, screenshotDisplayType
+
+        static var key: String = "appScreenshotSets"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    enum AppScreenshots: String, CaseIterable, NestableQueryParameter {
+        case appScreenshotSet, assetDeliveryState, assetToken, assetType, fileName, fileSize, imageAsset,
+             sourceFileChecksum, uploadOperations, uploaded
+
+        static var key: String = "appScreenshots"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    enum AppStoreVersionLocalizations: String, CaseIterable, NestableQueryParameter {
+        case appPreviewSets, appScreenshotSets, appStoreVersion, description, keywords, locale, marketingUrl,
+             promotionalText, supportUrl, whatsNew
+
+        static var key: String = "appStoreVersionLocalizations"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    enum ScreenshotDisplayType: String, CaseIterable, NestableQueryParameter {
+
+        // TODO: Snake case.
+        case APP_IPHONE_65, APP_IPHONE_58, APP_IPHONE_55, APP_IPHONE_47, APP_IPHONE_40, APP_IPHONE_35,
+             APP_IPAD_PRO_3GEN_129, APP_IPAD_PRO_3GEN_11, APP_IPAD_PRO_129, APP_IPAD_105, APP_IPAD_97,
+             APP_DESKTOP, APP_WATCH_SERIES_4, APP_WATCH_SERIES_3, APP_APPLE_TV,
+             IMESSAGE_APP_IPHONE_65, IMESSAGE_APP_IPHONE_58, IMESSAGE_APP_IPHONE_55, IMESSAGE_APP_IPHONE_47,
+             IMESSAGE_APP_IPHONE_40,
+             IMESSAGE_APP_IPAD_PRO_3GEN_129, IMESSAGE_APP_IPAD_PRO_3GEN_11, IMESSAGE_APP_IPAD_PRO_129,
+             IMESSAGE_APP_IPAD_105, IMESSAGE_APP_IPAD_97
+
+        static var key: String = "screenshotDisplayType"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+}

--- a/Sources/Endpoints/TestFlight/App Store Versions/ListAppScreenshotSets.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/ListAppScreenshotSets.swift
@@ -77,15 +77,31 @@ public extension ListAppScreenshotSetsForAppStoreVersionLocalization.Field {
     }
 
     enum ScreenshotDisplayType: String, CaseIterable, NestableQueryParameter {
-
-        // TODO: Snake case.
-        case APP_IPHONE_65, APP_IPHONE_58, APP_IPHONE_55, APP_IPHONE_47, APP_IPHONE_40, APP_IPHONE_35,
-             APP_IPAD_PRO_3GEN_129, APP_IPAD_PRO_3GEN_11, APP_IPAD_PRO_129, APP_IPAD_105, APP_IPAD_97,
-             APP_DESKTOP, APP_WATCH_SERIES_4, APP_WATCH_SERIES_3, APP_APPLE_TV,
-             IMESSAGE_APP_IPHONE_65, IMESSAGE_APP_IPHONE_58, IMESSAGE_APP_IPHONE_55, IMESSAGE_APP_IPHONE_47,
-             IMESSAGE_APP_IPHONE_40,
-             IMESSAGE_APP_IPAD_PRO_3GEN_129, IMESSAGE_APP_IPAD_PRO_3GEN_11, IMESSAGE_APP_IPAD_PRO_129,
-             IMESSAGE_APP_IPAD_105, IMESSAGE_APP_IPAD_97
+        case iPhone6Point5Inch = "APP_IPHONE_65"
+        case iPhone5Point8Inch = "APP_IPHONE_58"
+        case iPhone5Point5Inch = "APP_IPHONE_55"
+        case iPhone4Point7Inch = "APP_IPHONE_47"
+        case iPhone4Inch = "APP_IPHONE_40"
+        case iPhone3Point5Inch = "APP_IPHONE_35"
+        case iPadPro3rdGen12Point9Inch = "APP_IPAD_PRO_3GEN_129"
+        case iPadPro3rdGen11Inch = "APP_IPAD_PRO_3GEN_11"
+        case iPadPro12Point9Inch = "APP_IPAD_PRO_129"
+        case iPadPro10Point5Inch = "APP_IPAD_105"
+        case iPadPro9Point7Inch = "APP_IPAD_97"
+        case mac = "APP_DESKTOP"
+        case appleWatchSeries4 = "APP_WATCH_SERIES_4"
+        case appleWatchSeries3 = "APP_WATCH_SERIES_3"
+        case appleTV = "APP_APPLE_TV"
+        case iPhone6Point5InchMessaging = "IMESSAGE_APP_IPHONE_65"
+        case iPhone5Point8InchMessaging = "IMESSAGE_APP_IPHONE_58"
+        case iPhone5Point5InchMessaging = "IMESSAGE_APP_IPHONE_55"
+        case iPhone4Point7InchMessaging = "IMESSAGE_APP_IPHONE_47"
+        case iPhone4InchMessaging = "IMESSAGE_APP_IPHONE_40"
+        case iPadPro3rdGen12Point9InchMessaging = "IMESSAGE_APP_IPAD_PRO_3GEN_129"
+        case iPadPro3rdGen11InchMessaging = "IMESSAGE_APP_IPAD_PRO_3GEN_11"
+        case iPadPro12Point9InchMessaging = "IMESSAGE_APP_IPAD_PRO_129"
+        case iPadPro10Point5InchMessaging = "IMESSAGE_APP_IPAD_105"
+        case iPadPro9Point7InchMessaging = "IMESSAGE_APP_IPAD_97"
 
         static var key: String = "screenshotDisplayType"
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }

--- a/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionLocalization.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionLocalization.swift
@@ -11,6 +11,7 @@ public extension APIEndpoint where T == AppStoreVersionLocalizationResponse {
         whatsNew: String? = nil
     ) -> APIEndpoint {
         let request = AppStoreVersionLocalizationUpdateRequest(
+            id: id,
             description: description,
             keywords: keywords,
             marketingUrl: marketingUrl,

--- a/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionLocalization.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionLocalization.swift
@@ -5,9 +5,9 @@ public extension APIEndpoint where T == AppStoreVersionLocalizationResponse {
         appStoreVersionLocalizationWithId id: String,
         description: String? = nil,
         keywords: String? = nil,
-        marketingUrl: String? = nil,
+        marketingUrl: URL? = nil,
         promotionalText: String? = nil,
-        supportUrl: String? = nil,
+        supportUrl: URL? = nil,
         whatsNew: String? = nil
     ) -> APIEndpoint {
         let request = AppStoreVersionLocalizationUpdateRequest(

--- a/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionLocalization.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionLocalization.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public extension APIEndpoint where T == AppStoreVersionLocalizationResponse {
+    static func modify(
+        appStoreVersionLocalizationWithId id: String,
+        description: String? = nil,
+        keywords: String? = nil,
+        marketingUrl: String? = nil,
+        promotionalText: String? = nil,
+        supportUrl: String? = nil,
+        whatsNew: String? = nil
+    ) -> APIEndpoint {
+        let request = AppStoreVersionLocalizationUpdateRequest(
+            description: description,
+            keywords: keywords,
+            marketingUrl: marketingUrl,
+            promotionalText: promotionalText,
+            supportUrl: supportUrl,
+            whatsNew: whatsNew
+        )
+        return APIEndpoint(
+            path: "appStoreVersionLocalizations/\(id)",
+            method: .patch,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request)
+        )
+    }
+}

--- a/Sources/Endpoints/TestFlight/App Store Versions/ReadAppStoreVersionLocalization.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/ReadAppStoreVersionLocalization.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+public extension APIEndpoint where T == AppStoreVersionLocalization {
+    static func appStoreVersionLocalization(
+        withId id: String,
+        fields: [ReadAppStoreVersionLocalizationInformation.Field]? = nil,
+        include: [ReadAppStoreVersionLocalizationInformation.Include]? = nil,
+        limits: [ReadAppStoreVersionLocalizationInformation.Limit]? = nil
+    ) -> APIEndpoint {
+        var parameters = [String: Any]()
+        if let fields = fields { parameters.add(fields) }
+        if let include = include { parameters.add(include) }
+        if let limits = limits { parameters.add(limits) }
+        return APIEndpoint(
+            path: "appStoreVersionLocalizations/\(id)",
+            method: .get,
+            parameters: parameters
+        )
+    }
+}
+
+public enum ReadAppStoreVersionLocalizationInformation {
+    public enum Field: NestableQueryParameter {
+        case appPreviewSets([Field.AppPreviewSet])
+        case appScreenshotSets([Field.AppScreenshotSet])
+        case appStoreVersionLocalizations([Field.AppStoreVersionLocalization])
+
+        static var key: String = "fields"
+        var pair: Pair {
+            switch self {
+            case let .appPreviewSets(value):
+                return (Field.AppPreviewSet.key, value.map { $0.pair.value }.joinedByCommas())
+            case let .appScreenshotSets(value):
+                return (Field.AppScreenshotSet.key, value.map { $0.pair.value }.joinedByCommas())
+            case let .appStoreVersionLocalizations(value):
+                return (Field.AppStoreVersionLocalization.key, value.map { $0.pair.value }.joinedByCommas())
+            }
+        }
+    }
+
+    public enum Include: String, CaseIterable, NestableQueryParameter {
+        case appPreviewSets
+        case appScreenshotSets
+        case appStoreVersion
+
+        static var key: String = "include"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    public enum Limit: NestableQueryParameter {
+        /// Maximum: 50
+        case appPreviewSets(Int)
+
+        /// Maximum: 50
+        case appScreenshotSets(Int)
+
+        static var key: String = "limit"
+        var pair: Pair {
+            switch self {
+            case let .appPreviewSets(value):
+                return ("appPreviewSets", "\(value)")
+            case let .appScreenshotSets(value):
+                return ("appScreenshotSets", "\(value)")
+            }
+        }
+    }
+}
+
+public extension ReadAppStoreVersionLocalizationInformation.Field {
+    enum AppPreviewSet: String, CaseIterable, NestableQueryParameter {
+        case appPreviews, appStoreVersionLocalization, previewType
+
+        static var key: String = "appPreviewSets"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    enum AppScreenshotSet: String, CaseIterable, NestableQueryParameter {
+        case appScreenshots, appStoreVersionLocalization, screenshotDisplayType
+
+        static var key: String = "appScreenshotSets"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    enum AppStoreVersionLocalization: String, CaseIterable, NestableQueryParameter {
+        case appPreviewSets, appScreenshotSets, appStoreVersion, description, keywords, locale, marketingUrl,
+             promotionalText, supportUrl, whatsNew
+
+        static var key: String = "appStoreVersionLocalizations"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+}

--- a/Sources/Models/AppMediaAssetState.swift
+++ b/Sources/Models/AppMediaAssetState.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct AppMediaAssetState: Codable {
+    public let errors: [AppMediaStateError]?
+    public let state: String?
+    public let warnings: [AppMediaStateError]?
+}

--- a/Sources/Models/AppMediaStateError.swift
+++ b/Sources/Models/AppMediaStateError.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct AppMediaStateError: Codable {
+    public let code: String?
+    public let description: String?
+}

--- a/Sources/Models/AppPreview.swift
+++ b/Sources/Models/AppPreview.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+public struct AppPreview: Codable {
+    public struct Attributes: Codable {
+        public let assetDeliveryState: AppMediaAssetState?
+        public let fileName: String?
+        public let fileSize: Int?
+        public let mimeType: String?
+        public let previewFrameTimeCode: String?
+        public let previewImage: ImageAsset?
+        public let sourceFileChecksum: String?
+        public let uploadOperations: [UploadOperation]?
+        public let videoUrl: String?
+    }
+
+    public struct Relationships: Codable {
+        public let appPreviewSet: AppPreview.Relationships.AppPreviewSet?
+    }
+
+    public let attributes: AppScreenshot.Attributes?
+
+    public let id: String
+
+    public let relationships: AppScreenshot.Relationships?
+
+    public let type: String = "appPreview"
+
+    public let links: ResourceLinks<AppScreenshotResponse>
+}
+
+public extension AppPreview.Relationships {
+    struct AppPreviewSet: Codable {
+        public let data: AppPreview.Relationships.AppPreviewSet.Data?
+
+        public let links: AppPreview.Relationships.AppPreviewSet.Links?
+
+        public let meta: PagingInformation?
+    }
+}
+
+public extension AppPreview.Relationships.AppPreviewSet {
+    struct Data: Codable {
+        public let id: String
+
+        public let type: String = "appPreviewsSets"
+    }
+
+    struct Links: Codable {
+        /// uri-reference
+        public let related: URL?
+
+        /// uri-reference
+        public let `self`: URL?
+    }
+}

--- a/Sources/Models/AppPreviewResponse.swift
+++ b/Sources/Models/AppPreviewResponse.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct AppPreviewResponse: Codable {
+    public let data: AppPreview
+
+    public let links: PagedDocumentLinks
+}

--- a/Sources/Models/AppPreviewSet.swift
+++ b/Sources/Models/AppPreviewSet.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public struct AppPreviewSet: Codable {
+    public struct Attributes: Codable {
+        public let previewType: String?
+    }
+
+    public struct Relationships: Codable {
+        public let appPreviews: AppPreviewSet.Relationships.AppPreviews?
+
+        public let appStoreVersionLocalization: AppPreviewSet.Relationships.AppStoreVersionLocalization?
+    }
+
+    public let attributes: AppScreenshot.Attributes?
+
+    public let id: String
+
+    public let relationships: AppScreenshot.Relationships?
+
+    public let type: String = "appPreviewSets"
+
+    public let links: ResourceLinks<AppScreenshotResponse>
+}
+
+public extension AppPreviewSet.Relationships {
+    struct AppPreviews: Codable {
+        public let data: AppPreviewSet.Relationships.AppPreviews.Data?
+
+        public let links: AppPreviewSet.Relationships.AppPreviews.Links?
+
+        public let meta: PagingInformation?
+    }
+
+    struct AppStoreVersionLocalization: Codable {
+        public let data: AppPreviewSet.Relationships.AppStoreVersionLocalization.Data?
+
+        public let links: AppPreviewSet.Relationships.AppStoreVersionLocalization.Links?
+    }
+}
+
+public extension AppPreviewSet.Relationships.AppPreviews {
+    struct Data: Codable {
+        public let id: String
+
+        public let type: String = "appPreviews"
+    }
+
+    struct Links: Codable {
+        /// uri-reference
+        public let related: URL?
+
+        /// uri-reference
+        public let `self`: URL?
+    }
+}
+
+public extension AppPreviewSet.Relationships.AppStoreVersionLocalization {
+    struct Data: Codable {
+        public let id: String
+
+        public let type: String = "appStoreVersionLocalizations"
+    }
+
+    struct Links: Codable {
+        /// uri-reference
+        public let related: URL?
+
+        /// uri-reference
+        public let `self`: URL?
+    }
+}

--- a/Sources/Models/AppPreviewSetsResponse.swift
+++ b/Sources/Models/AppPreviewSetsResponse.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct AppPreviewSetsResponse: Codable {
+    public let data: [AppPreviewSet]
+
+    public let included: [AppPreview]
+
+    public let links: PagedDocumentLinks
+
+    public let meta: PagingInformation?
+}

--- a/Sources/Models/AppPreviewsResponse.swift
+++ b/Sources/Models/AppPreviewsResponse.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct AppPreviewsResponse: Codable {
+    public let data: [AppPreview]
+
+    public let links: PagedDocumentLinks
+
+    public let meta: PagingInformation?
+}

--- a/Sources/Models/AppScreenshot.swift
+++ b/Sources/Models/AppScreenshot.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public struct AppScreenshot: Codable {
+    public struct Attributes: Codable {
+        public let assetDeliveryState: AppMediaAssetState?
+        public let assetToken: String?
+        public let assetType: String?
+        public let fileName: String?
+        public let fileSize: Int?
+        public let imageAsset: ImageAsset?
+        public let sourceFileChecksum: String?
+        public let uploadOperations: [UploadOperation]?
+    }
+
+    public struct Relationships: Codable {
+        public let appScreenshotSet: AppScreenshot.Relationships.AppScreenshotSet?
+    }
+
+    public let attributes: AppScreenshot.Attributes?
+
+    public let id: String
+
+    public let relationships: AppScreenshot.Relationships?
+
+    public let type: String = "appScreenshots"
+
+    public let links: ResourceLinks<AppScreenshotResponse>
+}
+
+public extension AppScreenshot.Relationships {
+    struct AppScreenshotSet: Codable {
+        public let data: AppScreenshot.Relationships.AppScreenshotSet.Data?
+
+        public let links: AppScreenshot.Relationships.AppScreenshotSet.Links?
+    }
+}
+
+public extension AppScreenshot.Relationships.AppScreenshotSet {
+    struct Data: Codable {
+        public let id: String
+
+        public let type: String = "appScreenshotSets"
+    }
+
+    struct Links: Codable {
+        /// uri-reference
+        public let related: URL?
+
+        /// uri-reference
+        public let `self`: URL?
+    }
+}

--- a/Sources/Models/AppScreenshotResponse.swift
+++ b/Sources/Models/AppScreenshotResponse.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct AppScreenshotResponse: Codable {
+    public let data: AppScreenshot
+
+    public let links: PagedDocumentLinks
+}

--- a/Sources/Models/AppScreenshotSet.swift
+++ b/Sources/Models/AppScreenshotSet.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public struct AppScreenshotSet: Codable {
+    public struct Attributes: Codable {
+        public let screenshotDisplayType: String?
+    }
+
+    public struct Relationships: Codable {
+        public let appScreenshots: AppScreenshotSet.Relationships.AppScreenshots?
+        public let appStoreVersionLocalization: AppScreenshotSet.Relationships.AppStoreVersionLocalization?
+    }
+
+    public let attributes: AppScreenshotSet.Attributes?
+
+    public let id: String
+
+    public let relationships: AppScreenshotSet.Relationships?
+
+    public let type: String = "appScreenshotSets"
+
+    public let links: ResourceLinks<AppScreenshotSetResponse>
+}
+
+public extension AppScreenshotSet.Relationships {
+    struct AppScreenshots: Codable {
+        public let data: [AppScreenshotSet.Relationships.AppScreenshots.Data]?
+
+        public let links: AppScreenshotSet.Relationships.AppScreenshots.Links?
+    }
+
+    struct AppStoreVersionLocalization: Codable {
+        public let data: AppScreenshotSet.Relationships.AppStoreVersionLocalization.Data?
+
+        public let links: AppScreenshotSet.Relationships.AppStoreVersionLocalization.Links?
+    }
+}
+
+public extension AppScreenshotSet.Relationships.AppScreenshots {
+    struct Data: Codable {
+        public let id: String
+
+        public let type: String = "appScreenshotSets"
+    }
+
+    struct Links: Codable {
+        public let related: URL?
+
+        public let `self`: URL?
+    }
+}
+
+public extension AppScreenshotSet.Relationships.AppStoreVersionLocalization {
+    struct Data: Codable {
+        public let id: String
+
+        public let type: String = "appScreenshotSets"
+    }
+
+    struct Links: Codable {
+        public let related: URL?
+
+        public let `self`: URL?
+    }
+}

--- a/Sources/Models/AppScreenshotSetResponse.swift
+++ b/Sources/Models/AppScreenshotSetResponse.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct AppScreenshotSetResponse: Codable {
+    public let data: AppScreenshotSet
+
+    public let included: [AppScreenshot]?
+
+    public let links: PagedDocumentLinks
+}

--- a/Sources/Models/AppScreenshotSetsResponse.swift
+++ b/Sources/Models/AppScreenshotSetsResponse.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct AppScreenshotSetsResponse: Codable {
+    public let data: [AppScreenshotSet]
+
+    public let included: [AppScreenshot]?
+
+    public let links: PagedDocumentLinks
+
+    public let meta: PagingInformation?
+}

--- a/Sources/Models/AppScreenshotsResponse.swift
+++ b/Sources/Models/AppScreenshotsResponse.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct AppScreenshotsResponse: Codable {
+    public let data: [AppScreenshot]
+
+    public let links: PagedDocumentLinks
+
+    public let meta: PagingInformation?
+}

--- a/Sources/Models/AppStoreVersionLocalizationCreateRequest.swift
+++ b/Sources/Models/AppStoreVersionLocalizationCreateRequest.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+public struct AppStoreVersionLocalizationCreateRequest: Codable {
+    public struct Data: Codable {
+        public let attributes: AppStoreVersionLocalizationCreateRequest.Data.Attributes
+
+        public let relationships: AppStoreVersionLocalizationCreateRequest.Data.Relationships
+
+        public let type: String = " appStoreVersionLocalizations"
+    }
+
+    public let data: AppStoreVersionLocalizationCreateRequest.Data
+
+    init(appStoreVersionId: String,
+         locale: String,
+         description: String? = nil,
+         keywords: String? = nil,
+         marketingUrl: String? = nil,
+         promotionalText: String? = nil,
+         supportUrl: String? = nil,
+         whatsNew: String? = nil)
+    {
+        self.data = .init(attributes:
+            .init(
+                locale: locale,
+                description: description,
+                keywords: keywords,
+                marketingUrl: marketingUrl,
+                promotionalText: promotionalText,
+                supportUrl: supportUrl,
+                whatsNew: whatsNew
+            ),
+            relationships: .init(appStoreVersion: .init(data: .init(id: appStoreVersionId))))
+    }
+}
+
+public extension AppStoreVersionLocalizationCreateRequest.Data {
+    struct Attributes: Codable {
+        public let locale: String
+
+        public let description: String?
+
+        public let keywords: String?
+
+        public let marketingUrl: String?
+
+        public let promotionalText: String?
+
+        public let supportUrl: String?
+
+        public let whatsNew: String?
+    }
+
+    struct Relationships: Codable {
+        public let appStoreVersion: AppStoreVersionLocalizationCreateRequest.Data.Relationships.AppStoreVersion
+    }
+}
+
+// MARK: BetaAppLocalizationCreateRequest.Data.Relationships
+
+public extension AppStoreVersionLocalizationCreateRequest.Data.Relationships {
+    struct AppStoreVersion: Codable {
+        public let data: AppStoreVersionLocalizationCreateRequest.Data.Relationships.AppStoreVersion.Data
+    }
+}
+
+// MARK: BetaAppLocalizationCreateRequest.Data.Relationships.App
+
+public extension AppStoreVersionLocalizationCreateRequest.Data.Relationships.AppStoreVersion {
+    struct Data: Codable {
+        public let id: String
+
+        public let type: String = "appStoreVersions"
+    }
+}

--- a/Sources/Models/AppStoreVersionLocalizationCreateRequest.swift
+++ b/Sources/Models/AppStoreVersionLocalizationCreateRequest.swift
@@ -6,7 +6,7 @@ public struct AppStoreVersionLocalizationCreateRequest: Codable {
 
         public let relationships: AppStoreVersionLocalizationCreateRequest.Data.Relationships
 
-        public let type: String = " appStoreVersionLocalizations"
+        public let type: String = "appStoreVersionLocalizations"
     }
 
     public let data: AppStoreVersionLocalizationCreateRequest.Data

--- a/Sources/Models/AppStoreVersionLocalizationCreateRequest.swift
+++ b/Sources/Models/AppStoreVersionLocalizationCreateRequest.swift
@@ -11,15 +11,16 @@ public struct AppStoreVersionLocalizationCreateRequest: Codable {
 
     public let data: AppStoreVersionLocalizationCreateRequest.Data
 
-    init(appStoreVersionId: String,
-         locale: String,
-         description: String? = nil,
-         keywords: String? = nil,
-         marketingUrl: String? = nil,
-         promotionalText: String? = nil,
-         supportUrl: String? = nil,
-         whatsNew: String? = nil)
-    {
+    init(
+        appStoreVersionId: String,
+        locale: String,
+        description: String? = nil,
+        keywords: String? = nil,
+        marketingUrl: URL? = nil,
+        promotionalText: String? = nil,
+        supportUrl: URL? = nil,
+        whatsNew: String? = nil
+    ) {
         self.data = .init(attributes:
             .init(
                 locale: locale,
@@ -42,11 +43,11 @@ public extension AppStoreVersionLocalizationCreateRequest.Data {
 
         public let keywords: String?
 
-        public let marketingUrl: String?
+        public let marketingUrl: URL?
 
         public let promotionalText: String?
 
-        public let supportUrl: String?
+        public let supportUrl: URL?
 
         public let whatsNew: String?
     }

--- a/Sources/Models/AppStoreVersionLocalizationUpdateRequest.swift
+++ b/Sources/Models/AppStoreVersionLocalizationUpdateRequest.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public struct AppStoreVersionLocalizationUpdateRequest: Codable {
+    public struct Data: Codable {
+        public let attributes: AppStoreVersionLocalizationUpdateRequest.Data.Attributes
+
+        public let type: String = "appStoreVersionLocalizations"
+    }
+
+    public let data: AppStoreVersionLocalizationUpdateRequest.Data
+
+    init(description: String? = nil,
+         keywords: String? = nil,
+         marketingUrl: String? = nil,
+         promotionalText: String? = nil,
+         supportUrl: String? = nil,
+         whatsNew: String? = nil)
+    {
+        self.data = .init(attributes:
+            .init(
+                description: description,
+                keywords: keywords,
+                marketingUrl: marketingUrl,
+                promotionalText: promotionalText,
+                supportUrl: supportUrl,
+                whatsNew: whatsNew
+            ))
+    }
+}
+
+public extension AppStoreVersionLocalizationUpdateRequest.Data {
+    struct Attributes: Codable {
+        public let description: String?
+
+        public let keywords: String?
+
+        public let marketingUrl: String?
+
+        public let promotionalText: String?
+
+        public let supportUrl: String?
+
+        public let whatsNew: String?
+    }
+}

--- a/Sources/Models/AppStoreVersionLocalizationUpdateRequest.swift
+++ b/Sources/Models/AppStoreVersionLocalizationUpdateRequest.swift
@@ -9,22 +9,20 @@ public struct AppStoreVersionLocalizationUpdateRequest: Codable {
 
     public let data: AppStoreVersionLocalizationUpdateRequest.Data
 
-    init(description: String? = nil,
-         keywords: String? = nil,
-         marketingUrl: String? = nil,
-         promotionalText: String? = nil,
-         supportUrl: String? = nil,
-         whatsNew: String? = nil)
-    {
-        self.data = .init(attributes:
-            .init(
-                description: description,
-                keywords: keywords,
-                marketingUrl: marketingUrl,
-                promotionalText: promotionalText,
-                supportUrl: supportUrl,
-                whatsNew: whatsNew
-            ))
+    init(
+        description: String? = nil,
+        keywords: String? = nil,
+        marketingUrl: URL? = nil,
+        promotionalText: String? = nil,
+        supportUrl: URL? = nil,
+        whatsNew: String? = nil
+    ) {
+        self.data = .init(attributes: .init(description: description,
+                                            keywords: keywords,
+                                            marketingUrl: marketingUrl,
+                                            promotionalText: promotionalText,
+                                            supportUrl: supportUrl,
+                                            whatsNew: whatsNew))
     }
 }
 
@@ -34,11 +32,11 @@ public extension AppStoreVersionLocalizationUpdateRequest.Data {
 
         public let keywords: String?
 
-        public let marketingUrl: String?
+        public let marketingUrl: URL?
 
         public let promotionalText: String?
 
-        public let supportUrl: String?
+        public let supportUrl: URL?
 
         public let whatsNew: String?
     }

--- a/Sources/Models/AppStoreVersionLocalizationUpdateRequest.swift
+++ b/Sources/Models/AppStoreVersionLocalizationUpdateRequest.swift
@@ -4,12 +4,15 @@ public struct AppStoreVersionLocalizationUpdateRequest: Codable {
     public struct Data: Codable {
         public let attributes: AppStoreVersionLocalizationUpdateRequest.Data.Attributes
 
+        public let id: String
+
         public let type: String = "appStoreVersionLocalizations"
     }
 
     public let data: AppStoreVersionLocalizationUpdateRequest.Data
 
     init(
+        id: String,
         description: String? = nil,
         keywords: String? = nil,
         marketingUrl: URL? = nil,
@@ -22,7 +25,8 @@ public struct AppStoreVersionLocalizationUpdateRequest: Codable {
                                             marketingUrl: marketingUrl,
                                             promotionalText: promotionalText,
                                             supportUrl: supportUrl,
-                                            whatsNew: whatsNew))
+                                            whatsNew: whatsNew),
+                          id: id)
     }
 }
 

--- a/Sources/Models/UploadOperation.swift
+++ b/Sources/Models/UploadOperation.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct UploadOperation: Codable {
+    public let length: Int?
+    public let method: String?
+    public let offset: Int?
+    public let requestHeaders: [UploadOperationHeader]?
+    public let url: String?
+}

--- a/Sources/Models/UploadOperationHeader.swift
+++ b/Sources/Models/UploadOperationHeader.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct UploadOperationHeader: Codable {
+    public let name: String?
+    public let value: String?
+}

--- a/Tests/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersionLocalizationTests.swift
+++ b/Tests/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersionLocalizationTests.swift
@@ -1,0 +1,35 @@
+@testable import AppStoreConnect_Swift_SDK
+import Foundation
+import XCTest
+
+final class CreateAppStoreVersionLocalizationTests: XCTestCase {
+    let id = UUID().uuidString
+    let locale = "en-US"
+    let appDescription = "My App Is Great"
+    let url = URL(fileURLWithPath: "/usr/local/bin/appstore")
+    let buildIds = ["buildId"]
+
+    func testURLRequest() {
+        let endpoint = APIEndpoint.create(appStoreVersionLocalizationForVersionWithId: self.id,
+                                          locale: self.locale, description: self.appDescription,
+                                          keywords: nil, marketingUrl: self.url,
+                                          promotionalText: self.appDescription, supportUrl: self.url,
+                                          whatsNew: "Nothing")
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "POST")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations"
+        XCTAssertEqual(absoluteString, expected)
+        XCTAssertEqual(
+            request?.httpBody,
+            try? JSONEncoder().encode(AppStoreVersionLocalizationCreateRequest(
+                appStoreVersionId: self.id, locale: self.locale,
+                description: self.appDescription,
+                keywords: nil, marketingUrl: self.url, promotionalText: self.appDescription,
+                supportUrl: self.url, whatsNew: "Nothing"
+            ))
+        )
+    }
+}

--- a/Tests/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersionLocalizationsTests.swift
+++ b/Tests/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersionLocalizationsTests.swift
@@ -1,0 +1,16 @@
+@testable import AppStoreConnect_Swift_SDK
+import XCTest
+
+final class DeleteAppStoreVersionLocalizationsTests: XCTestCase {
+    func testURLRequest() {
+        let id = UUID().uuidString
+        let endpoint = APIEndpoint.delete(appStoreVersionLocalizationWithId: id)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "DELETE")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/\(id)"
+        XCTAssertEqual(absoluteString, expected)
+    }
+}

--- a/Tests/Endpoints/TestFlight/App Store Versions/ListAppPreviewSets.swift
+++ b/Tests/Endpoints/TestFlight/App Store Versions/ListAppPreviewSets.swift
@@ -1,0 +1,41 @@
+@testable import AppStoreConnect_Swift_SDK
+import XCTest
+
+final class ListAppPreviewSetsTests: XCTestCase {
+    func testURLRequest() {
+        let id = UUID().uuidString
+        let endpoint = APIEndpoint.appPreviewSets(
+            forAppStoreVersionLocalization: id,
+            fields: [
+                .appPreviewSets([
+                    .appPreviews,
+                    .appStoreVersionLocalization,
+                    .previewType
+                ]),
+                .appPreviews([
+                    .appPreviewSet,
+                    .assetDeliveryState,
+                    .fileName,
+                    .fileSize,
+                    .mimeType,
+                    .previewFrameTimeCode,
+                    .previewImage,
+                    .sourceFileChecksum,
+                    .uploadOperations,
+                    .uploaded
+                ])
+            ], includes: [
+                .appPreviews,
+                .appStoreVersionLocalization
+            ], limit: 50
+        )
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected =
+            "https://api.appstoreconnect.apple.com/v1/appStoreVersions/\(id)/appPreviewSets?fields%5BappPreviewSets%5D=appPreviews%2CappStoreVersionLocalization%2CpreviewType&fields%5BappPreviews%5D=appPreviewSet%2CassetDeliveryState%2CfileName%2CfileSize%2CmimeType%2CpreviewFrameTimeCode%2CpreviewImage%2CsourceFileChecksum%2CuploadOperations%2Cuploaded&include=appPreviews%2CappStoreVersionLocalization&limit=50"
+        XCTAssertEqual(absoluteString, expected)
+    }
+}

--- a/Tests/Endpoints/TestFlight/App Store Versions/ListAppScreenshotSetsTests.swift
+++ b/Tests/Endpoints/TestFlight/App Store Versions/ListAppScreenshotSetsTests.swift
@@ -1,0 +1,42 @@
+@testable import AppStoreConnect_Swift_SDK
+import XCTest
+
+final class ListAppScreenshotSetsTests: XCTestCase {
+    func testURLRequest() {
+        let id = UUID().uuidString
+        let endpoint = APIEndpoint.appScreenshotSets(
+            forAppStoreVersionLocalization: id,
+            fields: [
+                .appScreenshotSets([
+                    .appScreenshots,
+                    .appStoreVersionLocalization,
+                    .screenshotDisplayType
+                ]),
+                .appScreenshots([
+                    .appScreenshotSet,
+                    .assetDeliveryState,
+                    .assetToken,
+                    .assetType,
+                    .fileName,
+                    .fileSize,
+                    .imageAsset,
+                    .sourceFileChecksum,
+                    .uploadOperations,
+                    .uploaded
+                ]),
+                .appStoreVersionLocalizations([.locale])
+            ], includes: [
+                .appScreenshots,
+                .appStoreVersionLocalization
+            ], limit: 50
+        )
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected =
+            "https://api.appstoreconnect.apple.com/v1/appStoreVersions/\(id)/appScreenshotSets?fields%5BappScreenshotSets%5D=appScreenshots%2CappStoreVersionLocalization%2CscreenshotDisplayType&fields%5BappScreenshots%5D=appScreenshotSet%2CassetDeliveryState%2CassetToken%2CassetType%2CfileName%2CfileSize%2CimageAsset%2CsourceFileChecksum%2CuploadOperations%2Cuploaded&fields%5BappStoreVersionLocalizations%5D=locale&include=appScreenshots%2CappStoreVersionLocalization&limit=50"
+        XCTAssertEqual(absoluteString, expected)
+    }
+}

--- a/Tests/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionLocalizationTests.swift
+++ b/Tests/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionLocalizationTests.swift
@@ -1,0 +1,35 @@
+@testable import AppStoreConnect_Swift_SDK
+import Foundation
+import XCTest
+
+final class ModifyAppStoreVersionLocalizationTests: XCTestCase {
+    let id = UUID().uuidString
+    let locale = "en-US"
+    let appDescription = "My App Is Great"
+    let url = URL(fileURLWithPath: "/usr/local/bin/appstore")
+    let buildIds = ["buildId"]
+
+    func testURLRequest() {
+        let endpoint = APIEndpoint.modify(appStoreVersionLocalizationWithId: self.id,
+                                          description: self.appDescription,
+                                          keywords: nil, marketingUrl: self.url,
+                                          promotionalText: self.appDescription, supportUrl: self.url,
+                                          whatsNew: "Nothing")
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "PATCH")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/\(id)"
+        XCTAssertEqual(absoluteString, expected)
+        XCTAssertEqual(
+            request?.httpBody,
+            try? JSONEncoder().encode(AppStoreVersionLocalizationUpdateRequest(
+                id: self.id,
+                description: self.appDescription,
+                keywords: nil, marketingUrl: self.url, promotionalText: self.appDescription,
+                supportUrl: self.url, whatsNew: "Nothing"
+            ))
+        )
+    }
+}

--- a/Tests/Endpoints/TestFlight/App Store Versions/ReadAppStoreVersionLocalizationTests.swift
+++ b/Tests/Endpoints/TestFlight/App Store Versions/ReadAppStoreVersionLocalizationTests.swift
@@ -1,0 +1,31 @@
+@testable import AppStoreConnect_Swift_SDK
+import XCTest
+
+final class ReadAppStoreVersionLocalizationTests: XCTestCase {
+    func testURLRequest() {
+        let id = UUID().uuidString
+        let endpoint = APIEndpoint.appStoreVersionLocalization(
+            withId: id, fields: [
+                .appPreviewSets([
+                    .appPreviews,
+                    .appStoreVersionLocalization,
+                    .previewType
+                ])
+            ], include: [
+                .appPreviewSets,
+                .appScreenshotSets,
+                .appStoreVersion
+            ], limits: [
+                .appPreviewSets(50),
+                .appScreenshotSets(100)
+            ]
+        )
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected =
+            "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/\(id)?fields%5BappPreviewSets%5D=appPreviews%2CappStoreVersionLocalization%2CpreviewType&include=appPreviewSets%2CappScreenshotSets%2CappStoreVersion&limit%5BappPreviewSets%5D=50&limit%5BappScreenshotSets%5D=100"
+        XCTAssertEqual(absoluteString, expected)
+    }
+}


### PR DESCRIPTION
These APIs are now available:

- https://developer.apple.com/documentation/appstoreconnectapi/read_app_store_version_localization_information
- https://developer.apple.com/documentation/appstoreconnectapi/create_an_app_store_version_localization
- https://developer.apple.com/documentation/appstoreconnectapi/modify_an_app_store_version_localization
- https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_store_version_localization
- https://developer.apple.com/documentation/appstoreconnectapi/list_all_app_preview_sets_for_an_app_store_version_localization (NEW!)

This API is already in master:

- https://developer.apple.com/documentation/appstoreconnectapi/list_all_app_store_version_localizations_for_an_app_store_version

~~This API is not included because I do not know exactly what it does:~~

- ~~https://developer.apple.com/documentation/appstoreconnectapi/list_all_app_preview_sets_for_an_app_store_version_localization~~

~~It seems my app didn't make use of this App Store feature but I'll probably add it anyway in upcoming days.~~
