### PR TITLE
Fix Read Beta Group Information and update to match Apple's docs

### DIFF
--- a/Sources/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformation.swift
+++ b/Sources/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformation.swift
@@ -102,9 +102,9 @@ extension ReadBetaGroupInformation.Field {
     }
     
     public enum Build: String, CaseIterable, NestableQueryParameter {
-        case app, appEncryptionDeclaration, betaAppReviewSubmission, betaBuildLocalizations, betaGroups, buildBetaDetail, expirationDate, expired, iconAssetToken, individualTesters, minOsVersion, preReleaseVersion, processingState, uploadedDate, usesNonExemptEncryption, version
+        case app, appEncryptionDeclaration, appStoreVersion, betaAppReviewSubmission, betaBuildLocalizations, betaGroups, buildBetaDetail, diagnosticSignatures, expirationDate, expired, iconAssetToken, icons, individualTesters, minOsVersion, perfPowerMetrics, preReleaseVersion, processingState, uploadedDate, usesNonExemptEncryption, version
 
-        static var key: String = "build"
+        static var key: String = "builds"
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
     }
 }

--- a/Sources/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformation.swift
+++ b/Sources/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformation.swift
@@ -81,9 +81,9 @@ public enum ReadBetaGroupInformation {
 extension ReadBetaGroupInformation.Field {
     
     public enum App: String, CaseIterable, NestableQueryParameter {
-        case betaAppLocalizations, betaAppReviewDetail, betaGroups, betaLicenseAgreement, betaTesters, builds, bundleId, name, preReleaseVersions, primaryLocale, sku
+        case appInfos, appStoreVersions, availableInNewTerritories, availableTerritories, betaAppLocalizations, betaAppReviewDetail, betaGroups, betaLicenseAgreement, betaTesters, builds, bundleId, contentRightsDeclaration, endUserLicenseAgreement, gameCenterEnabledVersions, inAppPurchases, isOrEverWasMadeForKids, name, perfPowerMetrics, preOrder, preReleaseVersions, prices, primaryLocale, sku
 
-        static var key: String = "app"
+        static var key: String = "apps"
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
     }
     

--- a/Sources/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformation.swift
+++ b/Sources/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformation.swift
@@ -97,7 +97,7 @@ extension ReadBetaGroupInformation.Field {
     public enum BetaTester: String, CaseIterable, NestableQueryParameter {
         case apps, betaGroups, builds, email, firstName, inviteType, lastName
 
-        static var key: String = "betaTester"
+        static var key: String = "betaTesters"
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
     }
     

--- a/Sources/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformation.swift
+++ b/Sources/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformation.swift
@@ -88,9 +88,9 @@ extension ReadBetaGroupInformation.Field {
     }
     
     public enum BetaGroup: String, CaseIterable, NestableQueryParameter {
-        case app, betaTesters, builds, createdDate, isInternalGroup, name, publicLink, publicLinkEnabled, publicLinkId, publicLinkLimit, publicLinkLimitEnabled
+        case app, betaTesters, builds, createdDate, feedbackEnabled, isInternalGroup, name, publicLink, publicLinkEnabled, publicLinkId, publicLinkLimit, publicLinkLimitEnabled
 
-        static var key: String = "betaGroup"
+        static var key: String = "betaGroups"
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
     }
     

--- a/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
+++ b/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
@@ -9,6 +9,9 @@ import XCTest
 @testable import AppStoreConnect_Swift_SDK
 
 final class ReadBetaGroupInformationTests: XCTestCase {
+
+    // MARK: - Fields
+
     func test_fields_apps() {
         let endpoint = APIEndpoint.betaGroup(
             withId: "betaGroupId",
@@ -66,6 +69,23 @@ final class ReadBetaGroupInformationTests: XCTestCase {
 
         let absoluteString = request?.url?.absoluteString
         let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5Bbuilds%5D=app%2CappEncryptionDeclaration%2CappStoreVersion%2CbetaAppReviewSubmission%2CbetaBuildLocalizations%2CbetaGroups%2CbuildBetaDetail%2CdiagnosticSignatures%2CexpirationDate%2Cexpired%2CiconAssetToken%2Cicons%2CindividualTesters%2CminOsVersion%2CperfPowerMetrics%2CpreReleaseVersion%2CprocessingState%2CuploadedDate%2CusesNonExemptEncryption%2Cversion"
+        XCTAssertEqual(absoluteString, expected)
+    }
+
+    // MARK: - Include
+
+    func test_include_all() {
+        let endpoint = APIEndpoint.betaGroup(
+            withId: "betaGroupId",
+            fields: nil,
+            include: ReadBetaGroupInformation.Include.allCases,
+            limit: nil)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?include=app%2CbetaTesters%2Cbuilds"
         XCTAssertEqual(absoluteString, expected)
     }
 }

--- a/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
+++ b/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
@@ -120,26 +120,21 @@ final class ReadBetaGroupInformationTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?limit%5BbetaTesters%5D=5"
         XCTAssertEqual(absoluteString, expected)
     }
-}
 
-// MARK: - For reference - delete at the end
-extension ReadBetaGroupInformationTests {
-    func testURLRequest() {
+    // MARK: - Combined
+
+    func test_combined() {
         let endpoint = APIEndpoint.betaGroup(
             withId: "betaGroupId",
-            fields: [.apps(ReadBetaGroupInformation.Field.App.allCases),
-                     .betaGroups(ReadBetaGroupInformation.Field.BetaGroup.allCases),
-                     .betaTesters(ReadBetaGroupInformation.Field.BetaTester.allCases),
-                     .builds(ReadBetaGroupInformation.Field.Build.allCases)],
-            include: ReadBetaGroupInformation.Include.allCases,
-            limit: [.betaTesters(2),
-                    .builds(1)])
-        
+            fields: [.betaGroups([.betaTesters])],
+            include: [.app],
+            limit: [.builds(2), .betaTesters(5)])
+
         let request = try? endpoint.asURLRequest()
         XCTAssertEqual(request?.httpMethod, "GET")
-        
+
         let absoluteString = request?.url?.absoluteString
-        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5Bapp%5D=betaAppLocalizations%2CbetaAppReviewDetail%2CbetaGroups%2CbetaLicenseAgreement%2CbetaTesters%2Cbuilds%2CbundleId%2Cname%2CpreReleaseVersions%2CprimaryLocale%2Csku&fields%5BbetaGroup%5D=app%2CbetaTesters%2Cbuilds%2CcreatedDate%2CisInternalGroup%2Cname%2CpublicLink%2CpublicLinkEnabled%2CpublicLinkId%2CpublicLinkLimit%2CpublicLinkLimitEnabled&fields%5BbetaTester%5D=apps%2CbetaGroups%2Cbuilds%2Cemail%2CfirstName%2CinviteType%2ClastName&fields%5Bbuild%5D=app%2CappEncryptionDeclaration%2CbetaAppReviewSubmission%2CbetaBuildLocalizations%2CbetaGroups%2CbuildBetaDetail%2CexpirationDate%2Cexpired%2CiconAssetToken%2CindividualTesters%2CminOsVersion%2CpreReleaseVersion%2CprocessingState%2CuploadedDate%2CusesNonExemptEncryption%2Cversion&include=app%2CbetaTesters%2Cbuilds&limit%5BbetaTesters%5D=2&limit%5Bbuilds%5D=1"
+        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5BbetaGroups%5D=betaTesters&include=app&limit%5BbetaTesters%5D=5&limit%5Bbuilds%5D=2"
         XCTAssertEqual(absoluteString, expected)
     }
 }

--- a/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
+++ b/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
@@ -9,7 +9,24 @@ import XCTest
 @testable import AppStoreConnect_Swift_SDK
 
 final class ReadBetaGroupInformationTests: XCTestCase {
-    
+    func test_fields_apps() {
+        let endpoint = APIEndpoint.betaGroup(
+            withId: "betaGroupId",
+            fields: [.apps(ReadBetaGroupInformation.Field.App.allCases)],
+            include: nil,
+            limit: nil)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5Bapps%5D=appInfos%2CappStoreVersions%2CavailableInNewTerritories%2CavailableTerritories%2CbetaAppLocalizations%2CbetaAppReviewDetail%2CbetaGroups%2CbetaLicenseAgreement%2CbetaTesters%2Cbuilds%2CbundleId%2CcontentRightsDeclaration%2CendUserLicenseAgreement%2CgameCenterEnabledVersions%2CinAppPurchases%2CisOrEverWasMadeForKids%2Cname%2CperfPowerMetrics%2CpreOrder%2CpreReleaseVersions%2Cprices%2CprimaryLocale%2Csku"
+        XCTAssertEqual(absoluteString, expected)
+    }
+}
+
+// MARK: - For reference - delete at the end
+extension ReadBetaGroupInformationTests {
     func testURLRequest() {
         let endpoint = APIEndpoint.betaGroup(
             withId: "betaGroupId",

--- a/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
+++ b/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
@@ -53,6 +53,21 @@ final class ReadBetaGroupInformationTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5BbetaTesters%5D=apps%2CbetaGroups%2Cbuilds%2Cemail%2CfirstName%2CinviteType%2ClastName"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    func test_fields_builds() {
+        let endpoint = APIEndpoint.betaGroup(
+            withId: "betaGroupId",
+            fields: [.builds(ReadBetaGroupInformation.Field.Build.allCases)],
+            include: nil,
+            limit: nil)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5Bbuilds%5D=app%2CappEncryptionDeclaration%2CappStoreVersion%2CbetaAppReviewSubmission%2CbetaBuildLocalizations%2CbetaGroups%2CbuildBetaDetail%2CdiagnosticSignatures%2CexpirationDate%2Cexpired%2CiconAssetToken%2Cicons%2CindividualTesters%2CminOsVersion%2CperfPowerMetrics%2CpreReleaseVersion%2CprocessingState%2CuploadedDate%2CusesNonExemptEncryption%2Cversion"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete at the end

--- a/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
+++ b/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
@@ -38,6 +38,21 @@ final class ReadBetaGroupInformationTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5BbetaGroups%5D=app%2CbetaTesters%2Cbuilds%2CcreatedDate%2CfeedbackEnabled%2CisInternalGroup%2Cname%2CpublicLink%2CpublicLinkEnabled%2CpublicLinkId%2CpublicLinkLimit%2CpublicLinkLimitEnabled"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    func test_fields_betaTesters() {
+        let endpoint = APIEndpoint.betaGroup(
+            withId: "betaGroupId",
+            fields: [.betaTesters(ReadBetaGroupInformation.Field.BetaTester.allCases)],
+            include: nil,
+            limit: nil)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5BbetaTesters%5D=apps%2CbetaGroups%2Cbuilds%2Cemail%2CfirstName%2CinviteType%2ClastName"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete at the end

--- a/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
+++ b/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
@@ -23,6 +23,21 @@ final class ReadBetaGroupInformationTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5Bapps%5D=appInfos%2CappStoreVersions%2CavailableInNewTerritories%2CavailableTerritories%2CbetaAppLocalizations%2CbetaAppReviewDetail%2CbetaGroups%2CbetaLicenseAgreement%2CbetaTesters%2Cbuilds%2CbundleId%2CcontentRightsDeclaration%2CendUserLicenseAgreement%2CgameCenterEnabledVersions%2CinAppPurchases%2CisOrEverWasMadeForKids%2Cname%2CperfPowerMetrics%2CpreOrder%2CpreReleaseVersions%2Cprices%2CprimaryLocale%2Csku"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    func test_fields_betaGroups() {
+        let endpoint = APIEndpoint.betaGroup(
+            withId: "betaGroupId",
+            fields: [.betaGroups(ReadBetaGroupInformation.Field.BetaGroup.allCases)],
+            include: nil,
+            limit: nil)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?fields%5BbetaGroups%5D=app%2CbetaTesters%2Cbuilds%2CcreatedDate%2CfeedbackEnabled%2CisInternalGroup%2Cname%2CpublicLink%2CpublicLinkEnabled%2CpublicLinkId%2CpublicLinkLimit%2CpublicLinkLimitEnabled"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete at the end

--- a/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
+++ b/Tests/Endpoints/TestFlight/Beta Groups/ReadBetaGroupInformationTests.swift
@@ -88,6 +88,38 @@ final class ReadBetaGroupInformationTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?include=app%2CbetaTesters%2Cbuilds"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    // MARK: - Limits
+
+    func test_limit_builds() {
+        let endpoint = APIEndpoint.betaGroup(
+            withId: "betaGroupId",
+            fields: nil,
+            include: nil,
+            limit: [.builds(5)])
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?limit%5Bbuilds%5D=5"
+        XCTAssertEqual(absoluteString, expected)
+    }
+
+    func test_limit_betaTesters() {
+        let endpoint = APIEndpoint.betaGroup(
+            withId: "betaGroupId",
+            fields: nil,
+            include: nil,
+            limit: [.betaTesters(5)])
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/betaGroups/betaGroupId?limit%5BbetaTesters%5D=5"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete at the end


### PR DESCRIPTION
## Summary
The `Read Beta Group Information` API was broken, so I fixed the broken fields and updated all parameters to match [Apple's documentation](https://developer.apple.com/documentation/appstoreconnectapi/read_beta_group_information). Tests were added for each individual field.

## Changes in this PR
- `ReadBetaGroupInformation` was updated so it matches the API specs
- `ReadBetaGroupInformationTests` were updated with more granular tests for future expandability
- `.gitignore` was updated to ignore the `vendor` directory
- The `Gemfile.lock` file was checked in

## Questions
There were a couple changes I made at the end of my commits when I was following the instructions for Development. I updated the `.gitignore` file so that the `vendor` directory that is created by bundler no longer appears as a change. I also checked in the Gemfile.lock file so versions are pinned for the bundle install. If you would like me to remove either of these changes, please let me know.