### PR TITLE
Fix List Prerelease Versions and update to match Apple's docs

### DIFF
--- a/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
+++ b/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
@@ -129,9 +129,9 @@ extension ListPrereleaseVersions.Field {
     }
     
     public enum Build: String, CaseIterable, NestableQueryParameter {
-        case app, appEncryptionDeclaration, betaAppReviewSubmission, betaBuildLocalizations, betaGroups, buildBetaDetail, expirationDate, expired, iconAssetToken, individualTesters, minOsVersion, preReleaseVersion, processingState, uploadedDate, usesNonExemptEncryption, version
+        case app, appEncryptionDeclaration, appStoreVersion, betaAppReviewSubmission, betaBuildLocalizations, betaGroups, buildBetaDetail, diagnosticSignatures, expirationDate, expired, iconAssetToken, icons, individualTesters, minOsVersion, perfPowerMetrics, preReleaseVersion, processingState, uploadedDate, usesNonExemptEncryption, version
 
-        static var key: String = "build"
+        static var key: String = "builds"
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
     }
     

--- a/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
+++ b/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
@@ -65,7 +65,7 @@ public enum ListPrereleaseVersions {
         case buildsExpired([String])
         case buildsProcessingState([BuildsProcessingState])
         case builds([String])
-        case platform([String])
+        case platform([Platform])
         case version([String])
 
         static var key: String = "filter"
@@ -80,7 +80,7 @@ public enum ListPrereleaseVersions {
             case .builds(let value):
                 return ("builds", value.joinedByCommas())
             case .platform(let value):
-                return ("platform", value.joinedByCommas())
+                return (Platform.key, value.map({ $0.pair.value }).joinedByCommas())
             case .version(let value):
                 return ("version", value.joinedByCommas())
             }
@@ -149,6 +149,13 @@ extension ListPrereleaseVersions.Filter {
         case PROCESSING, FAILED, INVALID, VALID
 
         static var key: String = "builds.processingState"
+        var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
+    }
+
+    public enum Platform: String, CaseIterable, NestableQueryParameter {
+        case IOS, MAC_OS, TV_OS
+
+        static var key: String = "platform"
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
     }
 }

--- a/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
+++ b/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
@@ -122,9 +122,9 @@ public enum ListPrereleaseVersions {
 extension ListPrereleaseVersions.Field {
     
     public enum App: String, CaseIterable, NestableQueryParameter {
-        case betaAppLocalizations, betaAppReviewDetail, betaGroups, betaLicenseAgreement, betaTesters, builds, bundleId, name, preReleaseVersions, primaryLocale, sku
+        case appInfos, appStoreVersions, availableInNewTerritories, availableTerritories, betaAppLocalizations, betaAppReviewDetail, betaGroups, betaLicenseAgreement, betaTesters, builds, bundleId, contentRightsDeclaration, endUserLicenseAgreement, gameCenterEnabledVersions, inAppPurchases, isOrEverWasMadeForKids, name, perfPowerMetrics, preOrder, preReleaseVersions, prices, primaryLocale, sku
 
-        static var key: String = "App"
+        static var key: String = "apps"
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
     }
     

--- a/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
+++ b/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
@@ -138,7 +138,7 @@ extension ListPrereleaseVersions.Field {
     public enum PreReleaseVersion: String, CaseIterable, NestableQueryParameter {
         case app, builds, platform, version
 
-        static var key: String = "preReleaseVersion"
+        static var key: String = "preReleaseVersions"
         var pair: NestableQueryParameter.Pair { return (nil, rawValue) }
     }
 }

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -77,6 +77,22 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bapp%5D=123"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    func test_filter_buildsExpired() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: [.buildsExpired(["123"])],
+            include: nil,
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bbuilds.expired%5D=123"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -59,6 +59,24 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?fields%5BpreReleaseVersions%5D=app%2Cbuilds%2Cplatform%2Cversion"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    // MARK: - Filters
+
+    func test_filter_app() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: [.app(["123"])],
+            include: nil,
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bapp%5D=123"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -157,6 +157,24 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bversion%5D=123"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    // MARK: - Includes
+
+    func test_includes() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: nil,
+            include: [.app, .builds],
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?include=app%2Cbuilds"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -93,6 +93,22 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bbuilds.expired%5D=123"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    func test_filter_buildProcessingState() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: [.buildsProcessingState(ListPrereleaseVersions.Filter.BuildsProcessingState.allCases)],
+            include: nil,
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bbuilds.processingState%5D=PROCESSING%2CFAILED%2CINVALID%2CVALID"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -246,31 +246,3 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         XCTAssertEqual(absoluteString, expected)
     }
 }
-
-// MARK: - For reference - delete later
-extension ListPrereleaseVersionsTests {
-    func testURLRequest() {
-        let endpoint = APIEndpoint.prereleaseVersions(
-            fields: [
-                .apps(ListPrereleaseVersions.Field.App.allCases),
-                .builds(ListPrereleaseVersions.Field.Build.allCases),
-                .preReleaseVersions(ListPrereleaseVersions.Field.PreReleaseVersion.allCases)],
-            filter: [
-                .app(["appID"]),
-                .builds(["buildId"]),
-                .buildsExpired(["expired"]),
-                .buildsProcessingState(ListPrereleaseVersions.Filter.BuildsProcessingState.allCases),
-//                .platform(["platform"]),
-                .version(["version"])],
-            include: ListPrereleaseVersions.Include.allCases,
-            limit: [.builds(2)],
-            sort: ListPrereleaseVersions.Sort.allCases,
-            next: .test)
-        let request = try? endpoint.asURLRequest()
-        XCTAssertEqual(request?.httpMethod, "GET")
-        
-        let absoluteString = request?.url?.absoluteString
-        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?cursor=NEXT&fields%5BApp%5D=betaAppLocalizations%2CbetaAppReviewDetail%2CbetaGroups%2CbetaLicenseAgreement%2CbetaTesters%2Cbuilds%2CbundleId%2Cname%2CpreReleaseVersions%2CprimaryLocale%2Csku&fields%5Bbuild%5D=app%2CappEncryptionDeclaration%2CbetaAppReviewSubmission%2CbetaBuildLocalizations%2CbetaGroups%2CbuildBetaDetail%2CexpirationDate%2Cexpired%2CiconAssetToken%2CindividualTesters%2CminOsVersion%2CpreReleaseVersion%2CprocessingState%2CuploadedDate%2CusesNonExemptEncryption%2Cversion&fields%5BpreReleaseVersion%5D=app%2Cbuilds%2Cplatform%2Cversion&filter%5Bapp%5D=appID&filter%5Bbuilds.expired%5D=expired&filter%5Bbuilds.processingState%5D=PROCESSING%2CFAILED%2CINVALID%2CVALID&filter%5Bbuilds%5D=buildId&filter%5Bplatform%5D=platform&filter%5Bversion%5D=version&include=app%2Cbuilds&limit%5Bbuilds%5D=2&sort=%2Bversion%2C-version"
-        XCTAssertEqual(absoluteString, expected)
-    }
-}

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -193,6 +193,40 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?limit%5Bbuilds%5D=5"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    // MARK: - Sorts
+
+    func test_sort_versionAscending() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: nil,
+            include: nil,
+            limit: nil,
+            sort: [.versionAscending],
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?sort=%2Bversion"
+        XCTAssertEqual(absoluteString, expected)
+    }
+
+    func test_sort_versionDescending() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: nil,
+            include: nil,
+            limit: nil,
+            sort: [.versionDescending],
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?sort=-version"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -43,6 +43,22 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?fields%5Bbuilds%5D=app%2CappEncryptionDeclaration%2CappStoreVersion%2CbetaAppReviewSubmission%2CbetaBuildLocalizations%2CbetaGroups%2CbuildBetaDetail%2CdiagnosticSignatures%2CexpirationDate%2Cexpired%2CiconAssetToken%2Cicons%2CindividualTesters%2CminOsVersion%2CperfPowerMetrics%2CpreReleaseVersion%2CprocessingState%2CuploadedDate%2CusesNonExemptEncryption%2Cversion"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    func test_field_preReleaseVersions() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: [.preReleaseVersions(ListPrereleaseVersions.Field.PreReleaseVersion.allCases)],
+            filter: nil,
+            include: nil,
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?fields%5BpreReleaseVersions%5D=app%2Cbuilds%2Cplatform%2Cversion"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -141,6 +141,22 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bplatform%5D=IOS%2CMAC_OS%2CTV_OS"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    func test_filter_version() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: [.version(["123"])],
+            include: nil,
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bversion%5D=123"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -175,6 +175,24 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?include=app%2Cbuilds"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    // MARK: - Limits
+
+    func test_limit_builds() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: nil,
+            include: nil,
+            limit: [.builds(5)],
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?limit%5Bbuilds%5D=5"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -9,7 +9,26 @@ import XCTest
 @testable import AppStoreConnect_Swift_SDK
 
 final class ListPrereleaseVersionsTests: XCTestCase {
-    
+    // MARK: - Fields
+    func test_field_apps() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: [.apps(ListPrereleaseVersions.Field.App.allCases)],
+            filter: nil,
+            include: nil,
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?fields%5Bapps%5D=appInfos%2CappStoreVersions%2CavailableInNewTerritories%2CavailableTerritories%2CbetaAppLocalizations%2CbetaAppReviewDetail%2CbetaGroups%2CbetaLicenseAgreement%2CbetaTesters%2Cbuilds%2CbundleId%2CcontentRightsDeclaration%2CendUserLicenseAgreement%2CgameCenterEnabledVersions%2CinAppPurchases%2CisOrEverWasMadeForKids%2Cname%2CperfPowerMetrics%2CpreOrder%2CpreReleaseVersions%2Cprices%2CprimaryLocale%2Csku"
+        XCTAssertEqual(absoluteString, expected)
+    }
+}
+
+// MARK: - For reference - delete later
+extension ListPrereleaseVersionsTests {
     func testURLRequest() {
         let endpoint = APIEndpoint.prereleaseVersions(
             fields: [

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import AppStoreConnect_Swift_SDK
 
 final class ListPrereleaseVersionsTests: XCTestCase {
+
     // MARK: - Fields
+
     func test_field_apps() {
         let endpoint = APIEndpoint.prereleaseVersions(
             fields: [.apps(ListPrereleaseVersions.Field.App.allCases)],
@@ -23,6 +25,22 @@ final class ListPrereleaseVersionsTests: XCTestCase {
 
         let absoluteString = request?.url?.absoluteString
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?fields%5Bapps%5D=appInfos%2CappStoreVersions%2CavailableInNewTerritories%2CavailableTerritories%2CbetaAppLocalizations%2CbetaAppReviewDetail%2CbetaGroups%2CbetaLicenseAgreement%2CbetaTesters%2Cbuilds%2CbundleId%2CcontentRightsDeclaration%2CendUserLicenseAgreement%2CgameCenterEnabledVersions%2CinAppPurchases%2CisOrEverWasMadeForKids%2Cname%2CperfPowerMetrics%2CpreOrder%2CpreReleaseVersions%2Cprices%2CprimaryLocale%2Csku"
+        XCTAssertEqual(absoluteString, expected)
+    }
+
+    func test_field_builds() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: [.builds(ListPrereleaseVersions.Field.Build.allCases)],
+            filter: nil,
+            include: nil,
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?fields%5Bbuilds%5D=app%2CappEncryptionDeclaration%2CappStoreVersion%2CbetaAppReviewSubmission%2CbetaBuildLocalizations%2CbetaGroups%2CbuildBetaDetail%2CdiagnosticSignatures%2CexpirationDate%2Cexpired%2CiconAssetToken%2Cicons%2CindividualTesters%2CminOsVersion%2CperfPowerMetrics%2CpreReleaseVersion%2CprocessingState%2CuploadedDate%2CusesNonExemptEncryption%2Cversion"
         XCTAssertEqual(absoluteString, expected)
     }
 }

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -125,6 +125,22 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bbuilds%5D=123"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    func test_filter_platform() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: [.platform(ListPrereleaseVersions.Filter.Platform.allCases)],
+            include: nil,
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bplatform%5D=IOS%2CMAC_OS%2CTV_OS"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later
@@ -140,7 +156,7 @@ extension ListPrereleaseVersionsTests {
                 .builds(["buildId"]),
                 .buildsExpired(["expired"]),
                 .buildsProcessingState(ListPrereleaseVersions.Filter.BuildsProcessingState.allCases),
-                .platform(["platform"]),
+//                .platform(["platform"]),
                 .version(["version"])],
             include: ListPrereleaseVersions.Include.allCases,
             limit: [.builds(2)],

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -227,6 +227,24 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?sort=-version"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    // MARK: - Combined
+
+    func test_combined() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: [.apps(ListPrereleaseVersions.Field.App.allCases)],
+            filter: [.builds(["123"])],
+            include: [.app, .builds],
+            limit: [.builds(5)],
+            sort: [.versionAscending],
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?fields%5Bapps%5D=appInfos%2CappStoreVersions%2CavailableInNewTerritories%2CavailableTerritories%2CbetaAppLocalizations%2CbetaAppReviewDetail%2CbetaGroups%2CbetaLicenseAgreement%2CbetaTesters%2Cbuilds%2CbundleId%2CcontentRightsDeclaration%2CendUserLicenseAgreement%2CgameCenterEnabledVersions%2CinAppPurchases%2CisOrEverWasMadeForKids%2Cname%2CperfPowerMetrics%2CpreOrder%2CpreReleaseVersions%2Cprices%2CprimaryLocale%2Csku&filter%5Bbuilds%5D=123&include=app%2Cbuilds&limit%5Bbuilds%5D=5&sort=%2Bversion"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later

--- a/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
+++ b/Tests/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersionsTests.swift
@@ -109,6 +109,22 @@ final class ListPrereleaseVersionsTests: XCTestCase {
         let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bbuilds.processingState%5D=PROCESSING%2CFAILED%2CINVALID%2CVALID"
         XCTAssertEqual(absoluteString, expected)
     }
+
+    func test_filter_builds() {
+        let endpoint = APIEndpoint.prereleaseVersions(
+            fields: nil,
+            filter: [.builds(["123"])],
+            include: nil,
+            limit: nil,
+            sort: nil,
+            next: nil)
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "GET")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/preReleaseVersions?filter%5Bbuilds%5D=123"
+        XCTAssertEqual(absoluteString, expected)
+    }
 }
 
 // MARK: - For reference - delete later


### PR DESCRIPTION
## Summary
Updates the List Prerelease Versions API to fix incorrect parameter names and updated the API so it matches [Apple's latest documentation](https://developer.apple.com/documentation/appstoreconnectapi/list_prerelease_versions).

## Changes in this PR
- `ListPrereleaseVersions.swift` was updated with the fixes
- More granular tests were created in `ListPrereleaseVersionsTests.swift` to make testing easier to update in the future.