### PR TITLE
Add support for submitting an App Version for Review and CRUD for App Store Versions

### DIFF
--- a/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
+++ b/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
@@ -221,6 +221,8 @@
 		538D615E264E3DE700A61359 /* AppStoreVersionCreateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D615D264E3DE700A61359 /* AppStoreVersionCreateRequest.swift */; };
 		538D6160264E414100A61359 /* CreateAppStoreVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D615F264E414100A61359 /* CreateAppStoreVersion.swift */; };
 		538D6163264E441C00A61359 /* CreateAppStoreVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D6161264E440F00A61359 /* CreateAppStoreVersionTests.swift */; };
+		538D6167264E465400A61359 /* DeleteAppStoreVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D6166264E465400A61359 /* DeleteAppStoreVersion.swift */; };
+		538D6169264E46CE00A61359 /* DeleteAppStoreVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D6168264E46CE00A61359 /* DeleteAppStoreVersionTests.swift */; };
 		6D050F07241BE65700CBDABA /* ProfileCertificatesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D050F06241BE65700CBDABA /* ProfileCertificatesResponse.swift */; };
 		A72A23D32449384C0093A0E9 /* ProfileRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72A23D22449384C0093A0E9 /* ProfileRelationship.swift */; };
 		A72A23D5244938610093A0E9 /* ProfileRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72A23D4244938610093A0E9 /* ProfileRelationshipTests.swift */; };
@@ -772,6 +774,8 @@
 		538D615D264E3DE700A61359 /* AppStoreVersionCreateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreVersionCreateRequest.swift; sourceTree = "<group>"; };
 		538D615F264E414100A61359 /* CreateAppStoreVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersion.swift; sourceTree = "<group>"; };
 		538D6161264E440F00A61359 /* CreateAppStoreVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersionTests.swift; sourceTree = "<group>"; };
+		538D6166264E465400A61359 /* DeleteAppStoreVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAppStoreVersion.swift; sourceTree = "<group>"; };
+		538D6168264E46CE00A61359 /* DeleteAppStoreVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAppStoreVersionTests.swift; sourceTree = "<group>"; };
 		6D050F06241BE65700CBDABA /* ProfileCertificatesResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileCertificatesResponse.swift; sourceTree = "<group>"; };
 		A72A23D22449384C0093A0E9 /* ProfileRelationship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRelationship.swift; sourceTree = "<group>"; };
 		A72A23D4244938610093A0E9 /* ProfileRelationshipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRelationshipTests.swift; sourceTree = "<group>"; };
@@ -1624,6 +1628,7 @@
 			isa = PBXGroup;
 			children = (
 				538D6161264E440F00A61359 /* CreateAppStoreVersionTests.swift */,
+				538D6168264E46CE00A61359 /* DeleteAppStoreVersionTests.swift */,
 				538D615B264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift */,
 				09D74D7426314860003F6E5E /* Localizations */,
 				09D74D7326314855003F6E5E /* Phased Releases */,
@@ -1636,6 +1641,7 @@
 			isa = PBXGroup;
 			children = (
 				538D615F264E414100A61359 /* CreateAppStoreVersion.swift */,
+				538D6166264E465400A61359 /* DeleteAppStoreVersion.swift */,
 				538D6159264E374C00A61359 /* ModifyAppStoreVersion.swift */,
 				097063D626295E410083B9DF /* Localizations */,
 				097063D426295E230083B9DF /* Phased Releases */,
@@ -2474,6 +2480,7 @@
 				OBJ_663 /* ListBetaGroupsToWhichBetaTesterBelongs.swift in Sources */,
 				OBJ_664 /* ListBetaTesters.swift in Sources */,
 				OBJ_665 /* ListBuildsAssignedToBetaTester.swift in Sources */,
+				538D6167264E465400A61359 /* DeleteAppStoreVersion.swift in Sources */,
 				097063F226296ECD0083B9DF /* AppScreenshotSetsResponse.swift in Sources */,
 				OBJ_666 /* RemoveBetaTesterAccessToApps.swift in Sources */,
 				3FFAB1FA2529185600DD78B2 /* AppStoreVersionResponse.swift in Sources */,
@@ -2891,6 +2898,7 @@
 				50996B16241500190044308C /* GetAppTests.swift in Sources */,
 				50996B17241500190044308C /* ListBetaAppLocalizationsOfAppTests.swift in Sources */,
 				50996B35241500190044308C /* CancelUserInvitationTests.swift in Sources */,
+				538D6169264E46CE00A61359 /* DeleteAppStoreVersionTests.swift in Sources */,
 				50996B29241500190044308C /* ReadUserInformationTests.swift in Sources */,
 				50996B2B241500190044308C /* GetVisibleAppResourceIDsForUserTests.swift in Sources */,
 				50996B03241500190044308C /* ReadAppInformationOfPrereleaseVersionTests.swift in Sources */,

--- a/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
+++ b/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
@@ -215,6 +215,9 @@
 		5367F23F264E2FD8002A91AE /* AppStoreVersionSubmissionCreateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5367F23C264E2FD7002A91AE /* AppStoreVersionSubmissionCreateRequest.swift */; };
 		5367F240264E2FD8002A91AE /* AppStoreVersionSubmissionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5367F23D264E2FD8002A91AE /* AppStoreVersionSubmissionResponse.swift */; };
 		5367F243264E3001002A91AE /* CreateAppStoreVersionSubmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5367F242264E3001002A91AE /* CreateAppStoreVersionSubmissionTests.swift */; };
+		538D6158264E33E400A61359 /* AppStoreVersionUpdateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D6157264E33E400A61359 /* AppStoreVersionUpdateRequest.swift */; };
+		538D615A264E374C00A61359 /* ModifyAppStoreVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D6159264E374C00A61359 /* ModifyAppStoreVersion.swift */; };
+		538D615C264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D615B264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift */; };
 		6D050F07241BE65700CBDABA /* ProfileCertificatesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D050F06241BE65700CBDABA /* ProfileCertificatesResponse.swift */; };
 		A72A23D32449384C0093A0E9 /* ProfileRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72A23D22449384C0093A0E9 /* ProfileRelationship.swift */; };
 		A72A23D5244938610093A0E9 /* ProfileRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72A23D4244938610093A0E9 /* ProfileRelationshipTests.swift */; };
@@ -760,6 +763,9 @@
 		5367F23C264E2FD7002A91AE /* AppStoreVersionSubmissionCreateRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStoreVersionSubmissionCreateRequest.swift; sourceTree = "<group>"; };
 		5367F23D264E2FD8002A91AE /* AppStoreVersionSubmissionResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStoreVersionSubmissionResponse.swift; sourceTree = "<group>"; };
 		5367F242264E3001002A91AE /* CreateAppStoreVersionSubmissionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersionSubmissionTests.swift; sourceTree = "<group>"; };
+		538D6157264E33E400A61359 /* AppStoreVersionUpdateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreVersionUpdateRequest.swift; sourceTree = "<group>"; };
+		538D6159264E374C00A61359 /* ModifyAppStoreVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyAppStoreVersion.swift; sourceTree = "<group>"; };
+		538D615B264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyAppStoreVersionTests.swift; sourceTree = "<group>"; };
 		6D050F06241BE65700CBDABA /* ProfileCertificatesResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileCertificatesResponse.swift; sourceTree = "<group>"; };
 		A72A23D22449384C0093A0E9 /* ProfileRelationship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRelationship.swift; sourceTree = "<group>"; };
 		A72A23D4244938610093A0E9 /* ProfileRelationshipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRelationshipTests.swift; sourceTree = "<group>"; };
@@ -1180,8 +1186,8 @@
 				097063CD26294EE10083B9DF /* CreateAppStoreVersionLocalization.swift */,
 				097063C726294B2A0083B9DF /* DeleteAppStoreVersionLocalizations.swift */,
 				F072FA1825C41BBA0007F1BE /* ListAppStoreVersionLocalizations.swift */,
-				097063C926294BC70083B9DF /* ReadAppStoreVersionLocalization.swift */,
 				097063D726295E740083B9DF /* ModifyAppStoreVersionLocalization.swift */,
+				097063C926294BC70083B9DF /* ReadAppStoreVersionLocalization.swift */,
 			);
 			name = Localizations;
 			sourceTree = "<group>";
@@ -1611,9 +1617,10 @@
 		F072FA1125C41BA30007F1BE /* App Store Versions */ = {
 			isa = PBXGroup;
 			children = (
-				09D74D7526314A30003F6E5E /* Previews */,
+				538D615B264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift */,
 				09D74D7426314860003F6E5E /* Localizations */,
 				09D74D7326314855003F6E5E /* Phased Releases */,
+				09D74D7526314A30003F6E5E /* Previews */,
 			);
 			path = "App Store Versions";
 			sourceTree = "<group>";
@@ -1621,9 +1628,10 @@
 		F072FA1625C41BBA0007F1BE /* App Store Versions */ = {
 			isa = PBXGroup;
 			children = (
-				097063D92629604F0083B9DF /* Previews */,
+				538D6159264E374C00A61359 /* ModifyAppStoreVersion.swift */,
 				097063D626295E410083B9DF /* Localizations */,
 				097063D426295E230083B9DF /* Phased Releases */,
+				097063D92629604F0083B9DF /* Previews */,
 			);
 			path = "App Store Versions";
 			sourceTree = "<group>";
@@ -1880,6 +1888,7 @@
 				5367F23B264E2FD7002A91AE /* AppStoreVersionSubmission.swift */,
 				5367F23C264E2FD7002A91AE /* AppStoreVersionSubmissionCreateRequest.swift */,
 				5367F23D264E2FD8002A91AE /* AppStoreVersionSubmissionResponse.swift */,
+				538D6157264E33E400A61359 /* AppStoreVersionUpdateRequest.swift */,
 				OBJ_223 /* BetaAppLocalization.swift */,
 				OBJ_224 /* BetaAppLocalizationAppLinkageResponse.swift */,
 				OBJ_225 /* BetaAppLocalizationCreateRequest.swift */,
@@ -2640,6 +2649,7 @@
 				OBJ_818 /* BuildsResponse.swift in Sources */,
 				OBJ_819 /* BundleId.swift in Sources */,
 				3FFAB2172529190B00DD78B2 /* GetPrereleaseVersionIDsForApp.swift in Sources */,
+				538D615A264E374C00A61359 /* ModifyAppStoreVersion.swift in Sources */,
 				OBJ_820 /* BundleIdBundleIdCapabilitiesLinkagesResponse.swift in Sources */,
 				OBJ_821 /* BundleIdCapabilitiesResponse.swift in Sources */,
 				OBJ_822 /* BundleIdCapability.swift in Sources */,
@@ -2692,6 +2702,7 @@
 				OBJ_861 /* PrereleaseVersion.swift in Sources */,
 				OBJ_862 /* PrereleaseVersionAppLinkageResponse.swift in Sources */,
 				OBJ_863 /* PrereleaseVersionBuildsLinkagesResponse.swift in Sources */,
+				538D6158264E33E400A61359 /* AppStoreVersionUpdateRequest.swift in Sources */,
 				OBJ_864 /* PrereleaseVersionResponse.swift in Sources */,
 				OBJ_865 /* Profile.swift in Sources */,
 				OBJ_866 /* ProfileBundleIdLinkageResponse.swift in Sources */,
@@ -2791,6 +2802,7 @@
 				50996B04241500190044308C /* GetBuildIDsOfPrereleaseVersionTests.swift in Sources */,
 				50996B12241500190044308C /* GetBetaLicenseAgreementIDForAppTests.swift in Sources */,
 				50996AF9241500190044308C /* DeleteBetaAppLocalizationTests.swift in Sources */,
+				538D615C264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift in Sources */,
 				50996B3B241500190044308C /* AppRelationshipTests.swift in Sources */,
 				50996AFD241500190044308C /* ReadBetaAppReviewDetailInformationTests.swift in Sources */,
 				50996AB7241500190044308C /* ListBetaGroupsToWhichBetaTesterBelongsTests.swift in Sources */,

--- a/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
+++ b/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
@@ -210,6 +210,11 @@
 		50996B3E241500190044308C /* APIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50996AAF241500190044308C /* APIProviderTests.swift */; };
 		50996B3F241500190044308C /* JWTRequestsAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50996AB0241500190044308C /* JWTRequestsAuthenticatorTests.swift */; };
 		50996B41241500190044308C /* QueryParameterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50996AB2241500190044308C /* QueryParameterTests.swift */; };
+		5367F23A264E2FB9002A91AE /* CreateAppStoreVersionSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5367F239264E2FB9002A91AE /* CreateAppStoreVersionSubmission.swift */; };
+		5367F23E264E2FD8002A91AE /* AppStoreVersionSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5367F23B264E2FD7002A91AE /* AppStoreVersionSubmission.swift */; };
+		5367F23F264E2FD8002A91AE /* AppStoreVersionSubmissionCreateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5367F23C264E2FD7002A91AE /* AppStoreVersionSubmissionCreateRequest.swift */; };
+		5367F240264E2FD8002A91AE /* AppStoreVersionSubmissionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5367F23D264E2FD8002A91AE /* AppStoreVersionSubmissionResponse.swift */; };
+		5367F243264E3001002A91AE /* CreateAppStoreVersionSubmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5367F242264E3001002A91AE /* CreateAppStoreVersionSubmissionTests.swift */; };
 		6D050F07241BE65700CBDABA /* ProfileCertificatesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D050F06241BE65700CBDABA /* ProfileCertificatesResponse.swift */; };
 		A72A23D32449384C0093A0E9 /* ProfileRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72A23D22449384C0093A0E9 /* ProfileRelationship.swift */; };
 		A72A23D5244938610093A0E9 /* ProfileRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72A23D4244938610093A0E9 /* ProfileRelationshipTests.swift */; };
@@ -750,6 +755,11 @@
 		50996AAF241500190044308C /* APIProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = APIProviderTests.swift; path = Tests/APIProviderTests.swift; sourceTree = SOURCE_ROOT; };
 		50996AB0241500190044308C /* JWTRequestsAuthenticatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JWTRequestsAuthenticatorTests.swift; path = Tests/JWTRequestsAuthenticatorTests.swift; sourceTree = SOURCE_ROOT; };
 		50996AB2241500190044308C /* QueryParameterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = QueryParameterTests.swift; path = Tests/QueryParameterTests.swift; sourceTree = SOURCE_ROOT; };
+		5367F239264E2FB9002A91AE /* CreateAppStoreVersionSubmission.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersionSubmission.swift; sourceTree = "<group>"; };
+		5367F23B264E2FD7002A91AE /* AppStoreVersionSubmission.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStoreVersionSubmission.swift; sourceTree = "<group>"; };
+		5367F23C264E2FD7002A91AE /* AppStoreVersionSubmissionCreateRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStoreVersionSubmissionCreateRequest.swift; sourceTree = "<group>"; };
+		5367F23D264E2FD8002A91AE /* AppStoreVersionSubmissionResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStoreVersionSubmissionResponse.swift; sourceTree = "<group>"; };
+		5367F242264E3001002A91AE /* CreateAppStoreVersionSubmissionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersionSubmissionTests.swift; sourceTree = "<group>"; };
 		6D050F06241BE65700CBDABA /* ProfileCertificatesResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileCertificatesResponse.swift; sourceTree = "<group>"; };
 		A72A23D22449384C0093A0E9 /* ProfileRelationship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRelationship.swift; sourceTree = "<group>"; };
 		A72A23D4244938610093A0E9 /* ProfileRelationshipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRelationshipTests.swift; sourceTree = "<group>"; };
@@ -1270,21 +1280,22 @@
 		50996A13241500190044308C /* TestFlight */ = {
 			isa = PBXGroup;
 			children = (
-				F072FA1125C41BA30007F1BE /* App Store Versions */,
-				50996A14241500190044308C /* BetaTesters */,
-				50996A24241500190044308C /* Beta App Review Submissions */,
 				50996A2A241500190044308C /* App Encryption Declarations */,
-				50996A30241500190044308C /* Builds */,
-				50996A47241500190044308C /* Beta License Agreements */,
-				50996A4D241500190044308C /* Beta Build Localizations */,
-				50996A55241500190044308C /* Build Beta Notifications */,
-				50996A57241500190044308C /* Build Beta Details */,
+				5367F241264E3001002A91AE /* App Store Review Submissions */,
+				F072FA1125C41BA30007F1BE /* App Store Versions */,
+				50996A74241500190044308C /* Apps */,
 				50996A5D241500190044308C /* Beta App Localizations */,
 				50996A65241500190044308C /* Beta App Review Detail */,
-				50996A6B241500190044308C /* Beta Tester Invitations */,
-				50996A6D241500190044308C /* Prerelease Versions */,
-				50996A74241500190044308C /* Apps */,
+				50996A24241500190044308C /* Beta App Review Submissions */,
+				50996A4D241500190044308C /* Beta Build Localizations */,
 				50996A84241500190044308C /* Beta Groups */,
+				50996A47241500190044308C /* Beta License Agreements */,
+				50996A6B241500190044308C /* Beta Tester Invitations */,
+				50996A14241500190044308C /* BetaTesters */,
+				50996A57241500190044308C /* Build Beta Details */,
+				50996A55241500190044308C /* Build Beta Notifications */,
+				50996A30241500190044308C /* Builds */,
+				50996A6D241500190044308C /* Prerelease Versions */,
 			);
 			path = TestFlight;
 			sourceTree = "<group>";
@@ -1557,6 +1568,22 @@
 			path = Tests/Models;
 			sourceTree = SOURCE_ROOT;
 		};
+		5367F238264E2FB9002A91AE /* App Store Review Submissions */ = {
+			isa = PBXGroup;
+			children = (
+				5367F239264E2FB9002A91AE /* CreateAppStoreVersionSubmission.swift */,
+			);
+			path = "App Store Review Submissions";
+			sourceTree = "<group>";
+		};
+		5367F241264E3001002A91AE /* App Store Review Submissions */ = {
+			isa = PBXGroup;
+			children = (
+				5367F242264E3001002A91AE /* CreateAppStoreVersionSubmissionTests.swift */,
+			);
+			path = "App Store Review Submissions";
+			sourceTree = "<group>";
+		};
 		A72A23E0244947FF0093A0E9 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
@@ -1822,11 +1849,6 @@
 		OBJ_205 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				092552A1262D6EDA00D6119F /* App Preview Sets */,
-				097063E42629635E0083B9DF /* Upload Operation */,
-				097063E12629621D0083B9DF /* App Media State */,
-				097063DC2629607A0083B9DF /* App Screenshot Sets */,
-				097063D326295CEA0083B9DF /* App Store Version Localizations */,
 				OBJ_206 /* App.swift */,
 				OBJ_207 /* AppBetaAppLocalizationsLinkagesResponse.swift */,
 				OBJ_208 /* AppBetaAppReviewDetailLinkageResponse.swift */,
@@ -1855,6 +1877,9 @@
 				3FFAB1EC2529185600DD78B2 /* AppStoreVersionResponse.swift */,
 				3FFAB1F22529185600DD78B2 /* AppStoreVersionsResponse.swift */,
 				3FFAB1F02529185600DD78B2 /* AppStoreVersionState.swift */,
+				5367F23B264E2FD7002A91AE /* AppStoreVersionSubmission.swift */,
+				5367F23C264E2FD7002A91AE /* AppStoreVersionSubmissionCreateRequest.swift */,
+				5367F23D264E2FD8002A91AE /* AppStoreVersionSubmissionResponse.swift */,
 				OBJ_223 /* BetaAppLocalization.swift */,
 				OBJ_224 /* BetaAppLocalizationAppLinkageResponse.swift */,
 				OBJ_225 /* BetaAppLocalizationCreateRequest.swift */,
@@ -2004,6 +2029,11 @@
 				OBJ_363 /* UserUpdateRequest.swift */,
 				OBJ_364 /* UserVisibleAppsLinkagesRequest.swift */,
 				OBJ_365 /* UserVisibleAppsLinkagesResponse.swift */,
+				097063E12629621D0083B9DF /* App Media State */,
+				092552A1262D6EDA00D6119F /* App Preview Sets */,
+				097063DC2629607A0083B9DF /* App Screenshot Sets */,
+				097063D326295CEA0083B9DF /* App Store Version Localizations */,
+				097063E42629635E0083B9DF /* Upload Operation */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2090,6 +2120,7 @@
 		OBJ_51 /* TestFlight */ = {
 			isa = PBXGroup;
 			children = (
+				5367F238264E2FB9002A91AE /* App Store Review Submissions */,
 				F072FA1625C41BBA0007F1BE /* App Store Versions */,
 				OBJ_52 /* App Encryption Declarations */,
 				OBJ_58 /* Apps */,
@@ -2339,6 +2370,7 @@
 				OBJ_579 /* GetAllCertificateIdsInProfile.swift in Sources */,
 				OBJ_580 /* GetAllDeviceResourceIdsInProfile.swift in Sources */,
 				097063D826295E740083B9DF /* ModifyAppStoreVersionLocalization.swift in Sources */,
+				5367F23E264E2FD8002A91AE /* AppStoreVersionSubmission.swift in Sources */,
 				OBJ_581 /* GetBundleResourceIdInProfile.swift in Sources */,
 				OBJ_582 /* ListAllCertificatesInProfile.swift in Sources */,
 				092552AB262D721600D6119F /* AppPreviewsResponse.swift in Sources */,
@@ -2445,6 +2477,7 @@
 				OBJ_680 /* GetBetaAppReviewSubmissionIDOfBuild.swift in Sources */,
 				OBJ_681 /* GetBetaBuildLocalizationIDsOfBuild.swift in Sources */,
 				OBJ_682 /* GetBuildBetaDetailsResourceIDForBuild.swift in Sources */,
+				5367F23F264E2FD8002A91AE /* AppStoreVersionSubmissionCreateRequest.swift in Sources */,
 				OBJ_683 /* GetResourceIDsOfIndividualTestersForBuild.swift in Sources */,
 				OBJ_684 /* GetResourceIDsOfPrereleaseVersionsForBuild.swift in Sources */,
 				3FFAB1F72529185600DD78B2 /* AppInfoResponse.swift in Sources */,
@@ -2458,6 +2491,7 @@
 				3FFAB1FE2529185600DD78B2 /* AppStoreVersionState.swift in Sources */,
 				OBJ_692 /* ReadBuildBetaDetailsInformationOfBuild.swift in Sources */,
 				OBJ_693 /* ReadBuildInformation.swift in Sources */,
+				5367F240264E2FD8002A91AE /* AppStoreVersionSubmissionResponse.swift in Sources */,
 				OBJ_694 /* ReadPrereleaseVersionOfBuild.swift in Sources */,
 				OBJ_695 /* RemoveAccessForBetaGroupsToBuild.swift in Sources */,
 				OBJ_696 /* RemoveIndividualTestersFromBuild.swift in Sources */,
@@ -2584,6 +2618,7 @@
 				OBJ_800 /* BuildBetaAppReviewSubmissionLinkageResponse.swift in Sources */,
 				OBJ_801 /* BuildBetaBuildLocalizationsLinkagesResponse.swift in Sources */,
 				OBJ_802 /* BuildBetaDetail.swift in Sources */,
+				5367F23A264E2FB9002A91AE /* CreateAppStoreVersionSubmission.swift in Sources */,
 				OBJ_803 /* BuildBetaDetailBuildLinkageResponse.swift in Sources */,
 				OBJ_804 /* BuildBetaDetailResponse.swift in Sources */,
 				OBJ_805 /* BuildBetaDetailUpdateRequest.swift in Sources */,
@@ -2769,6 +2804,7 @@
 				50996B1B241500190044308C /* ListBetaGroupsTests.swift in Sources */,
 				50996AD0241500190044308C /* ReadPrereleaseVersionOfBuildTests.swift in Sources */,
 				50996B0C241500190044308C /* GetBetaGroupIDsForAppTests.swift in Sources */,
+				5367F243264E3001002A91AE /* CreateAppStoreVersionSubmissionTests.swift in Sources */,
 				09D74D7F26314D7C003F6E5E /* ModifyAppStoreVersionLocalizationTests.swift in Sources */,
 				3FE44F41256FB602008DD90C /* ReadAppInfoOfAppTests.swift in Sources */,
 				50996ABC241500190044308C /* ListAppsForBetaTesterTests.swift in Sources */,

--- a/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
+++ b/AppStoreConnect-Swift-SDK.xcodeproj/project.pbxproj
@@ -218,6 +218,9 @@
 		538D6158264E33E400A61359 /* AppStoreVersionUpdateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D6157264E33E400A61359 /* AppStoreVersionUpdateRequest.swift */; };
 		538D615A264E374C00A61359 /* ModifyAppStoreVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D6159264E374C00A61359 /* ModifyAppStoreVersion.swift */; };
 		538D615C264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D615B264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift */; };
+		538D615E264E3DE700A61359 /* AppStoreVersionCreateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D615D264E3DE700A61359 /* AppStoreVersionCreateRequest.swift */; };
+		538D6160264E414100A61359 /* CreateAppStoreVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D615F264E414100A61359 /* CreateAppStoreVersion.swift */; };
+		538D6163264E441C00A61359 /* CreateAppStoreVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538D6161264E440F00A61359 /* CreateAppStoreVersionTests.swift */; };
 		6D050F07241BE65700CBDABA /* ProfileCertificatesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D050F06241BE65700CBDABA /* ProfileCertificatesResponse.swift */; };
 		A72A23D32449384C0093A0E9 /* ProfileRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72A23D22449384C0093A0E9 /* ProfileRelationship.swift */; };
 		A72A23D5244938610093A0E9 /* ProfileRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72A23D4244938610093A0E9 /* ProfileRelationshipTests.swift */; };
@@ -766,6 +769,9 @@
 		538D6157264E33E400A61359 /* AppStoreVersionUpdateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreVersionUpdateRequest.swift; sourceTree = "<group>"; };
 		538D6159264E374C00A61359 /* ModifyAppStoreVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyAppStoreVersion.swift; sourceTree = "<group>"; };
 		538D615B264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyAppStoreVersionTests.swift; sourceTree = "<group>"; };
+		538D615D264E3DE700A61359 /* AppStoreVersionCreateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreVersionCreateRequest.swift; sourceTree = "<group>"; };
+		538D615F264E414100A61359 /* CreateAppStoreVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersion.swift; sourceTree = "<group>"; };
+		538D6161264E440F00A61359 /* CreateAppStoreVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAppStoreVersionTests.swift; sourceTree = "<group>"; };
 		6D050F06241BE65700CBDABA /* ProfileCertificatesResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileCertificatesResponse.swift; sourceTree = "<group>"; };
 		A72A23D22449384C0093A0E9 /* ProfileRelationship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRelationship.swift; sourceTree = "<group>"; };
 		A72A23D4244938610093A0E9 /* ProfileRelationshipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRelationshipTests.swift; sourceTree = "<group>"; };
@@ -1617,6 +1623,7 @@
 		F072FA1125C41BA30007F1BE /* App Store Versions */ = {
 			isa = PBXGroup;
 			children = (
+				538D6161264E440F00A61359 /* CreateAppStoreVersionTests.swift */,
 				538D615B264E3B8E00A61359 /* ModifyAppStoreVersionTests.swift */,
 				09D74D7426314860003F6E5E /* Localizations */,
 				09D74D7326314855003F6E5E /* Phased Releases */,
@@ -1628,6 +1635,7 @@
 		F072FA1625C41BBA0007F1BE /* App Store Versions */ = {
 			isa = PBXGroup;
 			children = (
+				538D615F264E414100A61359 /* CreateAppStoreVersion.swift */,
 				538D6159264E374C00A61359 /* ModifyAppStoreVersion.swift */,
 				097063D626295E410083B9DF /* Localizations */,
 				097063D426295E230083B9DF /* Phased Releases */,
@@ -1880,6 +1888,7 @@
 				OBJ_222 /* AppsResponse.swift */,
 				3FFAB1F42529185600DD78B2 /* AppStoreAgeRating.swift */,
 				3FFAB1EF2529185600DD78B2 /* AppStoreVersion.swift */,
+				538D615D264E3DE700A61359 /* AppStoreVersionCreateRequest.swift */,
 				F072FA1C25C41BCD0007F1BE /* AppStoreVersionPhasedReleaseResponse.swift */,
 				3FFAB1F52529185600DD78B2 /* AppStoreVersionRelationship.swift */,
 				3FFAB1EC2529185600DD78B2 /* AppStoreVersionResponse.swift */,
@@ -2554,6 +2563,7 @@
 				OBJ_742 /* BetaAppLocalization.swift in Sources */,
 				OBJ_743 /* BetaAppLocalizationAppLinkageResponse.swift in Sources */,
 				OBJ_744 /* BetaAppLocalizationCreateRequest.swift in Sources */,
+				538D615E264E3DE700A61359 /* AppStoreVersionCreateRequest.swift in Sources */,
 				OBJ_745 /* BetaAppLocalizationResponse.swift in Sources */,
 				OBJ_746 /* BetaAppLocalizationUpdateRequest.swift in Sources */,
 				OBJ_747 /* BetaAppLocalizationsResponse.swift in Sources */,
@@ -2563,6 +2573,7 @@
 				OBJ_750 /* BetaAppReviewDetailResponse.swift in Sources */,
 				OBJ_751 /* BetaAppReviewDetailUpdateRequest.swift in Sources */,
 				3FFAB1FB2529185600DD78B2 /* AppInfosResponse.swift in Sources */,
+				538D6160264E414100A61359 /* CreateAppStoreVersion.swift in Sources */,
 				OBJ_752 /* BetaAppReviewDetailsResponse.swift in Sources */,
 				OBJ_753 /* BetaAppReviewSubmission.swift in Sources */,
 				OBJ_754 /* BetaAppReviewSubmissionBuildLinkageResponse.swift in Sources */,
@@ -2852,6 +2863,7 @@
 				50996B19241500190044308C /* ListBetaTestersInBetaGroupTests.swift in Sources */,
 				50996B20241500190044308C /* ModifyBetaGroupTests.swift in Sources */,
 				50996AEE241500190044308C /* ReadBetaBuildLocalizationInformationTests.swift in Sources */,
+				538D6163264E441C00A61359 /* CreateAppStoreVersionTests.swift in Sources */,
 				50996B1A241500190044308C /* RemoveBuildsFromBetaGroupTests.swift in Sources */,
 				50996B37241500190044308C /* DownloadSalesAndTrendsReportsTests.swift in Sources */,
 				50996ADD241500190044308C /* ListIndividualTestersForBuildTests.swift in Sources */,

--- a/Sources/Endpoints/TestFlight/App Store Review Submissions/CreateAppStoreVersionSubmission.swift
+++ b/Sources/Endpoints/TestFlight/App Store Review Submissions/CreateAppStoreVersionSubmission.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public extension APIEndpoint where T == AppStoreVersionSubmissionResponse {
+    static func create(
+        appStoreVersionSubmissionForVersionWithId versionId: String
+    ) -> APIEndpoint {
+        let request = AppStoreVersionSubmissionCreateRequest(
+            appStoreVersionId: versionId
+        )
+        return APIEndpoint(
+            path: "appStoreVersionSubmissions",
+            method: .post,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request)
+        )
+    }
+}

--- a/Sources/Endpoints/TestFlight/App Store Review Submissions/CreateAppStoreVersionSubmission.swift
+++ b/Sources/Endpoints/TestFlight/App Store Review Submissions/CreateAppStoreVersionSubmission.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 public extension APIEndpoint where T == AppStoreVersionSubmissionResponse {
+
+    /// Submit an App Store version to App Review.
+    ///
+    /// # Reference
+    /// [Apple Documentation](https://developer.apple.com/documentation/appstoreconnectapi/create_an_app_store_version_submission)
     static func create(
         appStoreVersionSubmissionForVersionWithId versionId: String
     ) -> APIEndpoint {

--- a/Sources/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersion.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersion.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 public extension APIEndpoint where T == AppStoreVersionResponse {
+
+    /// Add a new App Store version or platform to an app.
+    ///
+    /// # Reference
+    /// [Apple Documentation](https://developer.apple.com/documentation/appstoreconnectapi/create_an_app_store_version)
     static func create(
         appStoreVersionForAppId id: String,
         versionString: String,

--- a/Sources/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersion.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersion.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public extension APIEndpoint where T == AppStoreVersionResponse {
+    static func create(
+        appStoreVersionForAppId id: String,
+        versionString: String,
+        platform: AppStoreVersionCreateRequest.Data.Attributes.Platform,
+        copyright: String? = nil,
+        earliestReleaseDate: Date? = nil,
+        releaseType: AppStoreVersionCreateRequest.Data.Attributes.ReleaseType? = nil,
+        usesIdfa: Bool? = nil,
+        buildId: String? = nil
+    ) -> APIEndpoint {
+        let request = AppStoreVersionCreateRequest(
+            appStoreVersionForAppId: id,
+            versionString: versionString,
+            platform: platform,
+            copyright: copyright,
+            earliestReleaseDate: earliestReleaseDate,
+            releaseType: releaseType,
+            usesIdfa: usesIdfa,
+            buildId: buildId
+        )
+        return APIEndpoint(
+            path: "appStoreVersions",
+            method: .post,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request)
+        )
+    }
+}

--- a/Sources/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersion.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersion.swift
@@ -1,5 +1,9 @@
 extension APIEndpoint where T == Void {
 
+    /// Delete an app store version that is associated with an app.
+    ///
+    /// # Reference
+    /// [Apple Documentation](https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_store_version)
     public static func delete(appStoreVersionWithId id: String) -> APIEndpoint {
         return APIEndpoint(path: "appStoreVersions/\(id)", method: .delete, parameters: nil)
     }

--- a/Sources/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersion.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersion.swift
@@ -1,0 +1,6 @@
+extension APIEndpoint where T == Void {
+
+    public static func delete(appStoreVersionWithId id: String) -> APIEndpoint {
+        return APIEndpoint(path: "appStoreVersions/\(id)", method: .delete, parameters: nil)
+    }
+}

--- a/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersion.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersion.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 public extension APIEndpoint where T == AppStoreVersionResponse {
+
+    /// Update the app store version for a specific app.
+    ///
+    /// # Reference
+    /// [Apple Documentation](https://developer.apple.com/documentation/appstoreconnectapi/modify_an_app_store_version)
     static func modify(
         appStoreVersionWithId id: String,
         buildId: String? = nil,

--- a/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersion.swift
+++ b/Sources/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersion.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public extension APIEndpoint where T == AppStoreVersionResponse {
+    static func modify(
+        appStoreVersionWithId id: String,
+        buildId: String? = nil,
+        copyright: String? = nil,
+        earliestReleaseDate: Date? = nil,
+        releaseType: AppStoreVersionUpdateRequest.Data.Attributes.ReleaseType? = nil,
+        usesIdfa: Bool? = nil,
+        versionString: String? = nil,
+        downloadable: Bool? = nil
+    ) -> APIEndpoint {
+        let request = AppStoreVersionUpdateRequest(
+            id: id,
+            buildId: buildId,
+            copyright: copyright,
+            earliestReleaseDate: earliestReleaseDate,
+            releaseType: releaseType,
+            usesIdfa: usesIdfa,
+            versionString: versionString,
+            downloadable: downloadable
+        )
+        return APIEndpoint(
+            path: "appStoreVersions/\(id)",
+            method: .patch,
+            parameters: nil,
+            body: try? JSONEncoder().encode(request)
+        )
+    }
+}

--- a/Sources/Models/AppStoreVersionCreateRequest.swift
+++ b/Sources/Models/AppStoreVersionCreateRequest.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+public struct AppStoreVersionCreateRequest: Codable {
+
+    public let data: AppStoreVersionCreateRequest.Data
+
+    public init(
+        appStoreVersionForAppId id: String,
+        versionString: String,
+        platform: AppStoreVersionCreateRequest.Data.Attributes.Platform,
+        copyright: String? = nil,
+        earliestReleaseDate: Date? = nil,
+        releaseType: AppStoreVersionCreateRequest.Data.Attributes.ReleaseType? = nil,
+        usesIdfa: Bool? = nil,
+        buildId: String? = nil
+    ) {
+        var build: AppStoreVersionCreateRequest.Data.Relationships.Build?
+        if let buildId = buildId {
+            build = .init(data: .init(id: buildId))
+        }
+
+        data = .init(attributes: .init(copyright: copyright,
+                                       earliestReleaseDate: earliestReleaseDate,
+                                       platform: platform,
+                                       releaseType: releaseType,
+                                       usesIdfa: usesIdfa,
+                                       versionString: versionString),
+                     relationships: .init(app: .init(data: .init(id: id)),
+                                          build: build))
+    }
+}
+
+// MARK: AppStoreVersionCreateRequest
+extension AppStoreVersionCreateRequest {
+
+    public struct Data: Codable {
+
+        public let attributes: AppStoreVersionCreateRequest.Data.Attributes
+
+        public let relationships: AppStoreVersionCreateRequest.Data.Relationships
+
+        public let type: String = "appStoreVersions"
+    }
+}
+
+// MARK: AppStoreVersionCreateRequest.Data
+extension AppStoreVersionCreateRequest.Data {
+
+    public struct Attributes: Codable {
+
+        public let copyright: String?
+
+        public let earliestReleaseDate: Date?
+
+        public let platform: AppStoreVersionCreateRequest.Data.Attributes.Platform
+
+        public let releaseType: AppStoreVersionCreateRequest.Data.Attributes.ReleaseType?
+
+        public let usesIdfa: Bool?
+
+        public let versionString: String
+    }
+
+    public struct Relationships: Codable {
+
+        public let app: AppStoreVersionCreateRequest.Data.Relationships.App
+
+        public let build: AppStoreVersionCreateRequest.Data.Relationships.Build?
+    }
+}
+
+// MARK: AppStoreVersionCreateRequest.Data.Attributes
+extension AppStoreVersionCreateRequest.Data.Attributes {
+
+    public enum Platform: String, CaseIterable, Codable {
+        case iOS = "IOS"
+        case macOS = "MAC_OS"
+        case tvOS = "TV_OS"
+    }
+
+    public enum ReleaseType: String, CaseIterable, Codable {
+        case manual = "MANUAL"
+        case afterApproval = "AFTER_APPROVAL"
+        case scheduled = "SCHEDULED"
+    }
+}
+
+// MARK: AppStoreVersionCreateRequest.Data.Relationships
+extension AppStoreVersionCreateRequest.Data.Relationships {
+
+    public struct App: Codable {
+
+        public let data: AppStoreVersionCreateRequest.Data.Relationships.App.Data
+    }
+
+    public struct Build: Codable {
+
+        public let data: AppStoreVersionCreateRequest.Data.Relationships.Build.Data?
+    }
+}
+
+// MARK: AppStoreVersionCreateRequest.Data.Relationships.App
+extension AppStoreVersionCreateRequest.Data.Relationships.App {
+
+    public struct Data: Codable {
+
+        public let id: String
+
+        public let type: String = "apps"
+    }
+}
+
+// MARK: AppStoreVersionCreateRequest.Data.Relationships.Build
+extension AppStoreVersionCreateRequest.Data.Relationships.Build {
+
+    public struct Data: Codable {
+
+        public let id: String
+
+        public let type: String = "builds"
+    }
+}

--- a/Sources/Models/AppStoreVersionSubmission.swift
+++ b/Sources/Models/AppStoreVersionSubmission.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public struct AppStoreVersionSubmission: Codable {
+    public let id: String
+
+    public let links: ResourceLinks<AppStoreVersionSubmissionResponse>
+
+    public let relationships: AppStoreVersionSubmission.Relationships?
+
+    public let type: String = "appStoreVersionSubmissions"
+}
+
+// MARK: AppStoreVersionSubmission
+extension AppStoreVersionSubmission {
+
+    public struct Relationships: Codable {
+
+        public let appStoreVersion: AppStoreVersionSubmission.Relationships.AppStoreVersion?
+        
+    }
+}
+
+// MARK: AppStoreVersionSubmission.Relationships
+extension AppStoreVersionSubmission.Relationships {
+
+    public struct AppStoreVersion: Codable {
+
+        public let data: AppStoreVersionSubmission.Relationships.AppStoreVersion.Data?
+
+        public let links: AppStoreVersionSubmission.Relationships.AppStoreVersion.Links?
+    }
+}
+
+// MARK: AppStoreVersionSubmission.Relationships.AppStoreVersion
+extension AppStoreVersionSubmission.Relationships.AppStoreVersion {
+
+    public struct Data: Codable {
+        public let id: String
+
+        public let type: String = "appStoreVersions"
+    }
+
+    public struct Links: Codable {
+        public let related: URL?
+
+        public let `self`: URL?
+    }
+}

--- a/Sources/Models/AppStoreVersionSubmissionCreateRequest.swift
+++ b/Sources/Models/AppStoreVersionSubmissionCreateRequest.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public struct AppStoreVersionSubmissionCreateRequest: Codable {
+
+    public struct Data: Codable {
+
+        public let relationships: AppStoreVersionSubmissionCreateRequest.Data.Relationships
+
+        public let type: String = "appStoreVersionSubmissions"
+    }
+
+    public let data: AppStoreVersionSubmissionCreateRequest.Data
+
+    init(appStoreVersionId: String) {
+        self.data = .init(relationships: .init(appStoreVersion: .init(data: .init(id: appStoreVersionId))))
+    }
+}
+
+// MARK: AppStoreVersionSubmissionCreateRequest.Data
+extension AppStoreVersionSubmissionCreateRequest.Data {
+
+    public struct Relationships: Codable {
+
+        public let appStoreVersion: AppStoreVersionSubmissionCreateRequest.Data.Relationships.AppStoreVersion
+
+    }
+}
+
+// MARK: - AppStoreVersionSubmissionCreateRequest.Data.Relationships
+extension AppStoreVersionSubmissionCreateRequest.Data.Relationships {
+    
+    public struct AppStoreVersion: Codable {
+
+        public let data: AppStoreVersionSubmissionCreateRequest.Data.Relationships.AppStoreVersion.Data
+
+    }
+}
+
+// MARK: AppStoreVersionSubmissionCreateRequest.Data.Relationships.AppStoreVersion
+extension AppStoreVersionSubmissionCreateRequest.Data.Relationships.AppStoreVersion {
+
+    public struct Data: Codable {
+
+        public let id: String
+
+        public let type: String = "appStoreVersions"
+
+    }
+}

--- a/Sources/Models/AppStoreVersionSubmissionResponse.swift
+++ b/Sources/Models/AppStoreVersionSubmissionResponse.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct AppStoreVersionSubmissionResponse: Codable {
+
+    public let data: AppStoreVersionSubmission
+
+    public let links: DocumentLinks
+
+}

--- a/Sources/Models/AppStoreVersionUpdateRequest.swift
+++ b/Sources/Models/AppStoreVersionUpdateRequest.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+public struct AppStoreVersionUpdateRequest: Codable {
+
+    public let data: AppStoreVersionUpdateRequest.Data
+
+    init(
+        id: String,
+        buildId: String? = nil,
+        copyright: String? = nil,
+        earliestReleaseDate: Date? = nil,
+        releaseType: AppStoreVersionUpdateRequest.Data.Attributes.ReleaseType? = nil,
+        usesIdfa: Bool? = nil,
+        versionString: String? = nil,
+        downloadable: Bool? = nil
+    ) {
+        var relationships: AppStoreVersionUpdateRequest.Data.Relationships?
+        if let buildId = buildId {
+            relationships = .init(build: .init(data: .init(id: buildId)))
+        }
+
+        data = .init(attributes: .init(copyright: copyright,
+                                       earliestReleaseDate: earliestReleaseDate,
+                                       releaseType: releaseType,
+                                       usesIdfa: usesIdfa,
+                                       versionString: versionString,
+                                       downloadable: downloadable),
+                     id: id,
+                     relationships: relationships)
+    }
+}
+
+// MARK: AppStoreVersionUpdateRequest
+extension AppStoreVersionUpdateRequest {
+
+    public struct Data: Codable {
+
+        public let attributes: AppStoreVersionUpdateRequest.Data.Attributes?
+
+        public let id: String
+
+        public let relationships: AppStoreVersionUpdateRequest.Data.Relationships?
+
+        public let type: String = "appStoreVersions"
+    }
+
+}
+
+// MARK: AppStoreVersionUpdateRequest.Data
+extension AppStoreVersionUpdateRequest.Data {
+
+    public struct Attributes: Codable {
+
+        public let copyright: String?
+
+        public let earliestReleaseDate: Date?
+
+        public let releaseType: ReleaseType?
+
+        public let usesIdfa: Bool?
+
+        public let versionString: String?
+
+        public let downloadable: Bool?
+    }
+
+    public struct Relationships: Codable {
+
+        public let build: AppStoreVersionUpdateRequest.Data.Relationships.Build?
+    }
+}
+
+// MARK: AppStoreVersionUpdateRequest.Data.Attributes
+extension AppStoreVersionUpdateRequest.Data.Attributes {
+
+    public enum ReleaseType: String, Codable {
+        case manual = "MANUAL"
+        case afterApproval = "AFTER_APPROVAL"
+        case scheduled = "SCHEDULED"
+    }
+}
+
+// MARK: AppStoreVersionUpdateRequest.Data.Relationships
+extension AppStoreVersionUpdateRequest.Data.Relationships {
+
+    public struct Build: Codable {
+
+        public let data: AppStoreVersionUpdateRequest.Data.Relationships.Build.Data?
+    }
+}
+
+// MARK: AppStoreVersionUpdateRequest.Data.Relationships.Build
+extension AppStoreVersionUpdateRequest.Data.Relationships.Build {
+
+    public struct Data: Codable {
+
+        public let id: String
+
+        public let type: String = "builds"
+    }
+}

--- a/Tests/Endpoints/TestFlight/App Store Review Submissions/CreateAppStoreVersionSubmissionTests.swift
+++ b/Tests/Endpoints/TestFlight/App Store Review Submissions/CreateAppStoreVersionSubmissionTests.swift
@@ -1,0 +1,21 @@
+@testable import AppStoreConnect_Swift_SDK
+import Foundation
+import XCTest
+
+final class CreateAppStoreVersionSubmissionTests: XCTestCase {
+    func testURLRequest() {
+        let id = UUID().uuidString
+        let endpoint = APIEndpoint.create(appStoreVersionSubmissionForVersionWithId: id)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "POST")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/appStoreVersionSubmissions"
+        XCTAssertEqual(absoluteString, expected)
+
+        let expectedBody = try? JSONEncoder().encode(AppStoreVersionSubmissionCreateRequest(appStoreVersionId: id))
+        XCTAssertNotNil(request?.httpBody)
+        XCTAssertEqual(request?.httpBody, expectedBody )
+    }
+}

--- a/Tests/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersionTests.swift
+++ b/Tests/Endpoints/TestFlight/App Store Versions/CreateAppStoreVersionTests.swift
@@ -1,0 +1,37 @@
+@testable import AppStoreConnect_Swift_SDK
+import Foundation
+import XCTest
+
+final class CreateAppStoreVersionTests: XCTestCase {
+    func testURLRequest() {
+        let id = UUID().uuidString
+        let buildId = UUID().uuidString
+        let earliestReleaseDate = Date()
+        let endpoint = APIEndpoint.create(appStoreVersionForAppId: id,
+                                          versionString: "mocked_version",
+                                          platform: .iOS,
+                                          copyright: "mocked_copyright",
+                                          earliestReleaseDate: earliestReleaseDate,
+                                          releaseType: .manual,
+                                          usesIdfa: true,
+                                          buildId: buildId)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "POST")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/appStoreVersions"
+        XCTAssertEqual(absoluteString, expected)
+
+        let expectedBody = try? JSONEncoder().encode(AppStoreVersionCreateRequest(appStoreVersionForAppId: id,
+                                                                                  versionString: "mocked_version",
+                                                                                  platform: .iOS,
+                                                                                  copyright: "mocked_copyright",
+                                                                                  earliestReleaseDate: earliestReleaseDate,
+                                                                                  releaseType: .manual,
+                                                                                  usesIdfa: true,
+                                                                                  buildId: buildId))
+        XCTAssertNotNil(request?.httpBody)
+        XCTAssertEqual(request?.httpBody, expectedBody )
+    }
+}

--- a/Tests/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersionTests.swift
+++ b/Tests/Endpoints/TestFlight/App Store Versions/DeleteAppStoreVersionTests.swift
@@ -1,0 +1,16 @@
+@testable import AppStoreConnect_Swift_SDK
+import XCTest
+
+final class DeleteAppStoreVersionTests: XCTestCase {
+    func testURLRequest() {
+        let id = UUID().uuidString
+        let endpoint = APIEndpoint.delete(appStoreVersionWithId: id)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "DELETE")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/appStoreVersions/\(id)"
+        XCTAssertEqual(absoluteString, expected)
+    }
+}

--- a/Tests/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionTests.swift
+++ b/Tests/Endpoints/TestFlight/App Store Versions/ModifyAppStoreVersionTests.swift
@@ -1,0 +1,36 @@
+@testable import AppStoreConnect_Swift_SDK
+import Foundation
+import XCTest
+
+final class ModifyAppStoreVersionTests: XCTestCase {
+    func testURLRequest() {
+        let id = UUID().uuidString
+        let earliestReleaseDate = Date()
+        let endpoint = APIEndpoint.modify(appStoreVersionWithId: id,
+                                          buildId: "1",
+                                          copyright: "mocked_copyright",
+                                          earliestReleaseDate: earliestReleaseDate,
+                                          releaseType: .manual,
+                                          usesIdfa: true,
+                                          versionString: "mocked_version",
+                                          downloadable: true)
+
+        let request = try? endpoint.asURLRequest()
+        XCTAssertEqual(request?.httpMethod, "PATCH")
+
+        let absoluteString = request?.url?.absoluteString
+        let expected = "https://api.appstoreconnect.apple.com/v1/appStoreVersions/\(id)"
+        XCTAssertEqual(absoluteString, expected)
+
+        let expectedBody = try? JSONEncoder().encode(AppStoreVersionUpdateRequest(id: id,
+                                                                                  buildId: "1",
+                                                                                  copyright: "mocked_copyright",
+                                                                                  earliestReleaseDate: earliestReleaseDate,
+                                                                                  releaseType: .manual,
+                                                                                  usesIdfa: true,
+                                                                                  versionString: "mocked_version",
+                                                                                  downloadable: true))
+        XCTAssertNotNil(request?.httpBody)
+        XCTAssertEqual(request?.httpBody, expectedBody )
+    }
+}


### PR DESCRIPTION
This changes adds support for the following APIs:
- [Create an App Store Version Submission](https://developer.apple.com/documentation/appstoreconnectapi/create_an_app_store_version_submission)
- [Create an App Store Version](https://developer.apple.com/documentation/appstoreconnectapi/create_an_app_store_version)
- [Modify an App Store Version](https://developer.apple.com/documentation/appstoreconnectapi/modify_an_app_store_version)
- [Delete an App Store Version](https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_store_version)