### PR TITLE
Add dSYMUrl and includesSymbols to BuildBundles

### DIFF
--- a/Sources/Models/BuildBundles.swift
+++ b/Sources/Models/BuildBundles.swift
@@ -18,6 +18,9 @@ public struct BuildBundles: Codable {
 
         // The type of the build bundle.
         public let bundleType: String
+		
+		// URL to the dSYM if available
+		public let dSYMUrl: URL?
     }
 
     // The opaque resource ID that uniquely identifies a Build

--- a/Sources/Models/BuildBundles.swift
+++ b/Sources/Models/BuildBundles.swift
@@ -18,12 +18,12 @@ public struct BuildBundles: Codable {
 
         // The type of the build bundle.
         public let bundleType: String
-		
-		// True if build bundle contains symbols
-		public let includesSymbols: Bool
-		
-		// URL to the dSYM if available
-		public let dSYMUrl: URL?
+
+        // True if build bundle contains symbols
+        public let includesSymbols: Bool
+
+        // URL to the dSYM if available
+        public let dSYMUrl: URL?
     }
 
     // The opaque resource ID that uniquely identifies a Build

--- a/Sources/Models/BuildBundles.swift
+++ b/Sources/Models/BuildBundles.swift
@@ -19,6 +19,9 @@ public struct BuildBundles: Codable {
         // The type of the build bundle.
         public let bundleType: String
 		
+		// True if build bundle contains symbols
+		public let includesSymbols: Bool
+		
 		// URL to the dSYM if available
 		public let dSYMUrl: URL?
     }


### PR DESCRIPTION
Added `dSYMUrl` and `includesSymbols` to `BuildBundles` struct.