### PR TITLE
fix: Add CREATE_APPS in UserRole enum

### DIFF
--- a/Sources/Models/UserRole.swift
+++ b/Sources/Models/UserRole.swift
@@ -20,4 +20,5 @@ public enum UserRole: String, CaseIterable, Codable {
     case accessToReports = "ACCESS_TO_REPORTS"
     case customerSupport = "CUSTOMER_SUPPORT"
     case cloudManagedAppDistribution = "CLOUD_MANAGED_APP_DISTRIBUTION"
+    case createApps = "CREATE_APPS"
 }


### PR DESCRIPTION
Added new enum case `CREATE_APPS` to fix Decoding error while retrieving User Roles from App Store Connect, due to the introduction of a new Role.