### PR TITLE
Make BuildBundleFileSize.links optional

### DIFF
--- a/Sources/Models/BuildBundleFileSize.swift
+++ b/Sources/Models/BuildBundleFileSize.swift
@@ -36,5 +36,5 @@ public struct BuildBundleFileSize: Codable {
     public let type: String = "buildBundleFileSizes"
 
     /// Navigational links that include the self-link.
-    public let links: ResourceLinks<BuildBundleFileSizesResponse>
+    public let links: ResourceLinks<BuildBundleFileSizesResponse>?
 }


### PR DESCRIPTION
We saw this not being returned in the API:

```
Error: keyNotFound(CodingKeys(stringValue: "links", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "data", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0)], debugDescription: "No value associated with key CodingKeys(stringValue: \"links\", intValue: nil) (\"links\").", underlyingError: nil)).
```

It's been fixed on Apple's side, but figured out we might as well treat it as optional to future-proof it.