### PR TITLE
Fix authentication refresh

### DIFF
--- a/Example/Shared/AppsListView.swift
+++ b/Example/Shared/AppsListView.swift
@@ -25,6 +25,11 @@ struct AppsListView: View {
                 ProgressView()
                     .opacity(viewModel.apps.isEmpty ? 1.0 : 0.0)
             }.navigationTitle("List of Apps")
+                .toolbar {
+                    Button("Refresh") {
+                        viewModel.loadApps()
+                    }
+                }
         }.onAppear {
             viewModel.loadApps()
         }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(

--- a/Sources/OpenAPI/app_store_connect_api_2.0_openapi.json
+++ b/Sources/OpenAPI/app_store_connect_api_2.0_openapi.json
@@ -24182,7 +24182,7 @@
             "type" : "array",
             "items" : {
               "type" : "string",
-              "enum" : [ ]
+              "enum" : [ "empty" ]
             }
           },
           "style" : "form",

--- a/Sources/OpenAPI/app_store_connect_api_2.0_openapi.json
+++ b/Sources/OpenAPI/app_store_connect_api_2.0_openapi.json
@@ -24182,7 +24182,7 @@
             "type" : "array",
             "items" : {
               "type" : "string",
-              "enum" : [ "empty" ]
+              "enum" : [ ]
             }
           },
           "style" : "form",


### PR DESCRIPTION
Fixes https://github.com/AvdLee/appstoreconnect-swift-sdk/issues/137 by making use of the current date for all refreshes.

We were refreshing the token correctly once expired, but by using a fixed base date, we would still fail.