### PR TITLE
Add localized error description

### DIFF
--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -35,7 +35,7 @@ public struct APIConfiguration {
 /// Provides access to all API Methods. Can be used to perform API requests.
 public final class APIProvider {
 
-    public enum Error: Swift.Error, CustomDebugStringConvertible {
+    public enum Error: Swift.Error, CustomDebugStringConvertible, LocalizedError {
         case requestGeneration
         case unknownResponseType
         case requestFailure(StatusCode, Data?, URL?)
@@ -44,6 +44,10 @@ public final class APIProvider {
         case dateDecodingError(String)
         case requestExecutorError(Swift.Error)
 
+        public var errorDescription: String? {
+            debugDescription
+        }
+        
         public var debugDescription: String {
             switch self {
             case .requestGeneration:


### PR DESCRIPTION
`print(error.localizedDescription)` used to be:

```
Something went wrong fetching the apps: The operation couldn’t be completed. (AppStoreConnect_Swift_SDK.APIProvider.Error error 0.)
```

And now is:

```
Something went wrong fetching the apps: Request https://api.appstoreconnect.apple.com/v1/builds/app.appId failed with status code 404 and response {
  "errors" : [ {
    "id" : "6bc5ebbc-0389-430d-9827-38e3820cdfbb",
    "status" : "404",
    "code" : "NOT_FOUND",
    "title" : "The specified resource does not exist",
    "detail" : "There is no resource of type 'builds' with id 'app.appId'"
  } ]
}).
```

Fixes #181 