### PR TITLE
Parse JSON error response

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ let apps = try await self.provider.request(request).data
 print("Did fetch \(apps.count) apps")
 ```
 
+### Handling errors
+Whenever an error is returned from a request, you can get the details by catching the error as follows:
+
+```swift
+do {
+    print(try await self.provider.request(requestWithError).data)
+} catch APIProvider.Error.requestFailure(let statusCode, let errorResponse, _) {
+    print("Request failed with statuscode: \(statusCode) and the following errors:")
+    errorResponse?.errors?.forEach({ error in
+        print("Error code: \(error.code)")
+        print("Error title: \(error.title)")
+        print("Error detail: \(error.detail)")
+    })
+} catch {
+    print("Something went wrong fetching the apps: \(error.localizedDescription)")
+}
+```
+
+The error title and detail should help you solve the failure.
+For more info regarding errors, see: [Parsing the Error Response Code](https://developer.apple.com/documentation/appstoreconnectapi/interpreting_and_handling_errors/parsing_the_error_response_code) as documented by Apple.
+
 ## Installation
 
 ### Swift Package Manager

--- a/Sources/Extensions/ErrorResponseExtensions.swift
+++ b/Sources/Extensions/ErrorResponseExtensions.swift
@@ -1,0 +1,22 @@
+//
+//  ErrorResponseExtensions.swift
+//  
+//
+//  Created by Antoine van der Lee on 29/07/2022.
+//
+
+import Foundation
+
+extension ErrorResponse: CustomStringConvertible {
+    public var description: String {
+        var errorString = "Related response error(s):"
+        errors?.forEach({ error in
+            errorString.append("""
+        \n\nThe request failed with response code \(error.status) \(error.code)
+
+        \(error.title). \(error.detail)
+        """)
+        })
+        return errorString
+    }
+}

--- a/Sources/RequestExecutor.swift
+++ b/Sources/RequestExecutor.swift
@@ -14,11 +14,18 @@ public struct Response<T> {
     public let requestURL: URL?
     public let statusCode: Int
     public let data: T?
+    public let errorResponse: ErrorResponse?
 
     public init(requestURL: URL?, statusCode: StatusCode, data: T?) {
         self.requestURL = requestURL
         self.statusCode = statusCode
         self.data = data
+
+        if let data = data as? Data {
+            self.errorResponse = try? APIProvider.jsonDecoder.decode(ErrorResponse.self, from: data)
+        } else {
+            self.errorResponse = nil
+        }
     }
 }
 


### PR DESCRIPTION
Allowing users to parse the returned error response and catch it:

```swift
do {
    print(try await self.provider.request(requestWithError).data)
} catch APIProvider.Error.requestFailure(let statusCode, let errorResponse, _) {
    print("Request failed with statuscode: \(statusCode) and the following errors:")
    errorResponse?.errors?.forEach({ error in
        print("Error code: \(error.code)")
        print("Error title: \(error.title)")
        print("Error detail: \(error.detail)")
    })
} catch {
    print("Something went wrong fetching the apps: \(error.localizedDescription)")
}
```

This PR also changed how errors are printed:

```
Request https://api.appstoreconnect.apple.com failed with status code 404. Related response error(s):

The request failed with response code 404 NOT_FOUND

The specified resource does not exist. There is no resource of type 'builds' with id 'app.appId').
```