### PR TITLE
Use Swift Package Plugin for generating OpenAPI code

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(
@@ -19,6 +19,27 @@ let package = Package(
             name: "AppStoreConnect-Swift-SDK",
             dependencies: ["URLQueryEncoder"],
             path: "Sources",
-            exclude: ["OpenAPI/app_store_connect_api_2.0_openapi.json"])
+            exclude: ["OpenAPI/app_store_connect_api_2.0_openapi.json"]
+        ),
+        .binaryTarget(
+            name: "create-api",
+            url: "https://github.com/CreateAPI/CreateAPI/releases/download/0.0.5/create-api.artifactbundle.zip",
+            checksum: "89c75ec3b2938d08b961b94e70e6dd6fa0ff52a90037304d41718cd5fb58bd24"
+        ),
+        .plugin(
+            name: "CreateAPI",
+            capability: .command(
+                intent: .custom(
+                    verb: "generate-open-api",
+                    description: "Generates the OpenAPI entities and paths using CreateAPI"
+                ),
+                permissions: [
+                    .writeToPackageDirectory(reason: "To output the generated source code")
+                ]
+            ),
+            dependencies: [
+                .target(name: "create-api")
+            ]
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .binaryTarget(
             name: "create-api", // Find the URL and checksum at https://github.com/createapi/createapi/releases/latest
             url: "https://github.com/CreateAPI/CreateAPI/releases/download/0.0.5/create-api.artifactbundle.zip",
-            checksum: "89c75ec3b2938d08b961b94e70e6dd6fa0ff52a90037304d41718cd5fb58bd24"
+            checksum: "89c75ec3b2938d08b961b94e70e6dd6fa0ff52a90037304d41718cd5fb58bd24" // Find at https://github.com/createapi/createapi/releases/latest
         ),
         .plugin(
             name: "CreateAPI",

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             exclude: ["OpenAPI/app_store_connect_api_2.0_openapi.json"]
         ),
         .binaryTarget(
-            name: "create-api",
+            name: "create-api", // Find the URL and checksum at https://github.com/createapi/createapi/releases/latest
             url: "https://github.com/CreateAPI/CreateAPI/releases/download/0.0.5/create-api.artifactbundle.zip",
             checksum: "89c75ec3b2938d08b961b94e70e6dd6fa0ff52a90037304d41718cd5fb58bd24"
         ),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "AppStoreConnect-Swift-SDK",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15)
+    ],
+    products: [
+        .library(name: "AppStoreConnect-Swift-SDK", targets: ["AppStoreConnect-Swift-SDK"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/CreateAPI/URLQueryEncoder.git", from: "0.2.0")
+    ],
+    targets: [
+        .testTarget(name: "AppStoreConnect-Swift-SDK-Tests", dependencies: ["AppStoreConnect-Swift-SDK"], path: "Tests"),
+        .target(
+            name: "AppStoreConnect-Swift-SDK",
+            dependencies: ["URLQueryEncoder"],
+            path: "Sources",
+            exclude: ["OpenAPI/app_store_connect_api_2.0_openapi.json"])
+    ]
+)

--- a/Plugins/CreateAPI/Plugin.swift
+++ b/Plugins/CreateAPI/Plugin.swift
@@ -1,0 +1,27 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct Plugin: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        let createAPI = try context.tool(named: "create-api")
+        let currentDirectoryURL =  URL(fileURLWithPath: context.package.directory.string)
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("OpenAPI")
+
+        let process = Process()
+        process.currentDirectoryURL = currentDirectoryURL
+        process.executableURL = URL(fileURLWithPath: createAPI.path.string)
+        process.arguments = [
+            "generate",
+            "app_store_connect_api_2.0_openapi.json",
+            "--module", "AppStoreConnect_Swift_SDK",
+            "--output", ".",
+            "--config", ".create-api.yml",
+            "--split"
+        ]
+
+        try process.run()
+        process.waitUntilExit()
+    }
+}

--- a/Plugins/CreateAPI/Plugin.swift
+++ b/Plugins/CreateAPI/Plugin.swift
@@ -5,12 +5,10 @@ import PackagePlugin
 struct Plugin: CommandPlugin {
     func performCommand(context: PluginContext, arguments: [String]) async throws {
         let createAPI = try context.tool(named: "create-api")
-        let currentDirectoryURL =  URL(fileURLWithPath: context.package.directory.string)
-            .appendingPathComponent("Sources")
-            .appendingPathComponent("OpenAPI")
+        let openAPIDirectory = context.package.directory.appending("Sources", "OpenAPI")
 
         let process = Process()
-        process.currentDirectoryURL = currentDirectoryURL
+        process.currentDirectoryURL = URL(fileURLWithPath: openAPIDirectory.string)
         process.executableURL = URL(fileURLWithPath: createAPI.path.string)
         process.arguments = [
             "generate",

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ bundle exec fastlane test
 ```
 
 ### Update OpenAPI generated code
-Using [CreateAPI](https://github.com/CreateAPI/CreateAPI).
+Using [CreateAPI](https://github.com/CreateAPI/CreateAPI), run the following:
 
-1. `cd` into the `Source/OpenAPI` folder
-2. Open terminal
-3. Execute: `create-api generate app_store_connect_api_2.0_openapi.json --module "AppStoreConnect_Swift_SDK" --output . --config .create-api.yml -s`
+```bash
+$ swift package --allow-writing-to-package-directory generate-open-api
+```
 
 ## Communication
 


### PR DESCRIPTION
👋 I'm currently working on CreateAPI/CreateAPI#48 and have been playing around with different ways to use Swift Package Plugin's to streamline workflows. Given that this project has been on my radar recently, I wanted to explore how we'd go about using plugins to replace your current workflows. The main motivation for all of this was purely for research, but I wanted to raise a PR anyway to see if it would interest you or not.

This approach uses the new artifactbundle format to defined CreateAPI as a binaryTarget dependency which may or may not streamline installing the appropriate version of CreateAPI on your machine. I then define a new `CommandPlugin` that wraps the invocation to the `create-api` cli allowing you to instead trigger generating with the following command:

```bash
$ swift package --allow-writing-to-package-directory generate-open-api
```

Things are relatively straightforward overall but the only downside that I came across while testing this is when it comes to supporting Swift 5.5. Since you can't define the plugin in **`Package.swift`** when supporting 5.5, I had to bump swift-tools-version to 5.6 and then add **`Package@swift-5.5.swift`** instead. This means that you'll have to keep both files around until you were to drop Swift 5.5/Xcode 13.3 support. 

Anyway, let me know what you think. I'm happy to to make any adjustments you might like, but I'm also happy to close this if you don't see it being worthwhile at the moment. Thanks! 