### PR TITLE
Update types to automatically conform to `Identifiable` where possible

### DIFF
--- a/Example/Shared/AppsListView.swift
+++ b/Example/Shared/AppsListView.swift
@@ -14,7 +14,7 @@ struct AppsListView: View {
     var body: some View {
         NavigationView {
             ZStack {
-                List(viewModel.apps, id: \.id) { app in
+                List(viewModel.apps) { app in
                     VStack(alignment: .leading) {
                         Text(app.attributes?.name ?? "Unknown name")
                             .font(.headline)

--- a/Sources/OpenAPI/.create-api.yml
+++ b/Sources/OpenAPI/.create-api.yml
@@ -17,7 +17,7 @@ paths:
   isAddingOperationIds: false
   # The types to import, by default uses "Get" (https://github.com/CreateAPI/Get)
   imports: []
-  # Inline simple requests, like the ones with a single parameter 
+  # Inline simple requests, like the ones with a single parameter
   isInliningSimpleRequests: true
   # Inline simple parametesr with few arguments.
   isInliningSimpleQueryParameters: true
@@ -29,13 +29,14 @@ paths:
 
 entities:
   isGeneratingCustomCodingKeys: false
+  isGeneratingIdentifiableConformance: true
 
 comments:
   # Generate comments
   isEnabled: true
   # Generate titles
   isAddingTitles: true
-  # Generate description 
+  # Generate description
   isAddingDescription: true
   # Generate examples
   isAddingExamples: true

--- a/Sources/OpenAPI/Entities/AgeRatingDeclaration.swift
+++ b/Sources/OpenAPI/Entities/AgeRatingDeclaration.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AgeRatingDeclaration: Codable {
+public struct AgeRatingDeclaration: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AgeRatingDeclarationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AgeRatingDeclarationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AgeRatingDeclarationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/App.swift
+++ b/Sources/OpenAPI/Entities/App.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct App: Codable {
+public struct App: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -131,7 +131,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -202,7 +202,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -276,7 +276,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -350,7 +350,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -424,7 +424,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -498,7 +498,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -571,7 +571,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -641,7 +641,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -712,7 +712,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -786,7 +786,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -859,7 +859,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -929,7 +929,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1000,7 +1000,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1074,7 +1074,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1149,7 +1149,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1223,7 +1223,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1297,7 +1297,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1371,7 +1371,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1445,7 +1445,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1519,7 +1519,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1593,7 +1593,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1667,7 +1667,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -1740,7 +1740,7 @@ public struct App: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppBetaTestersLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/AppBetaTestersLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppBetaTestersLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppCategory.swift
+++ b/Sources/OpenAPI/Entities/AppCategory.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppCategory: Codable {
+public struct AppCategory: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -65,7 +65,7 @@ public struct AppCategory: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -138,7 +138,7 @@ public struct AppCategory: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClip.swift
+++ b/Sources/OpenAPI/Entities/AppClip.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClip: Codable {
+public struct AppClip: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -64,7 +64,7 @@ public struct AppClip: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -135,7 +135,7 @@ public struct AppClip: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipAdvancedExperience.swift
+++ b/Sources/OpenAPI/Entities/AppClipAdvancedExperience.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClipAdvancedExperience: Codable {
+public struct AppClipAdvancedExperience: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -357,7 +357,7 @@ public struct AppClipAdvancedExperience: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -427,7 +427,7 @@ public struct AppClipAdvancedExperience: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -498,7 +498,7 @@ public struct AppClipAdvancedExperience: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipAdvancedExperienceCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipAdvancedExperienceCreateRequest.swift
@@ -312,7 +312,7 @@ public struct AppClipAdvancedExperienceCreateRequest: Codable {
 			public struct AppClip: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -356,7 +356,7 @@ public struct AppClipAdvancedExperienceCreateRequest: Codable {
 			public struct HeaderImage: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -400,7 +400,7 @@ public struct AppClipAdvancedExperienceCreateRequest: Codable {
 			public struct Localizations: Codable {
 				public var data: [Datum]
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipAdvancedExperienceImage.swift
+++ b/Sources/OpenAPI/Entities/AppClipAdvancedExperienceImage.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClipAdvancedExperienceImage: Codable {
+public struct AppClipAdvancedExperienceImage: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppClipAdvancedExperienceImageUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipAdvancedExperienceImageUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppClipAdvancedExperienceImageUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppClipAdvancedExperienceLocalization.swift
+++ b/Sources/OpenAPI/Entities/AppClipAdvancedExperienceLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClipAdvancedExperienceLocalization: Codable {
+public struct AppClipAdvancedExperienceLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppClipAdvancedExperienceLocalizationInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/AppClipAdvancedExperienceLocalizationInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClipAdvancedExperienceLocalizationInlineCreate: Codable {
+public struct AppClipAdvancedExperienceLocalizationInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppClipAdvancedExperienceUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipAdvancedExperienceUpdateRequest.swift
@@ -9,7 +9,7 @@ public struct AppClipAdvancedExperienceUpdateRequest: Codable {
 	public var data: Data
 	public var included: [AppClipAdvancedExperienceLocalizationInlineCreate]?
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -313,7 +313,7 @@ public struct AppClipAdvancedExperienceUpdateRequest: Codable {
 			public struct AppClip: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -357,7 +357,7 @@ public struct AppClipAdvancedExperienceUpdateRequest: Codable {
 			public struct HeaderImage: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -401,7 +401,7 @@ public struct AppClipAdvancedExperienceUpdateRequest: Codable {
 			public struct Localizations: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipAppStoreReviewDetail.swift
+++ b/Sources/OpenAPI/Entities/AppClipAppStoreReviewDetail.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClipAppStoreReviewDetail: Codable {
+public struct AppClipAppStoreReviewDetail: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -63,7 +63,7 @@ public struct AppClipAppStoreReviewDetail: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipAppStoreReviewDetailCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipAppStoreReviewDetailCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppClipAppStoreReviewDetailCreateRequest: Codable {
 			public struct AppClipDefaultExperience: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipAppStoreReviewDetailUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipAppStoreReviewDetailUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppClipAppStoreReviewDetailUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppClipDefaultExperience.swift
+++ b/Sources/OpenAPI/Entities/AppClipDefaultExperience.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClipDefaultExperience: Codable {
+public struct AppClipDefaultExperience: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -66,7 +66,7 @@ public struct AppClipDefaultExperience: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -136,7 +136,7 @@ public struct AppClipDefaultExperience: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -207,7 +207,7 @@ public struct AppClipDefaultExperience: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -280,7 +280,7 @@ public struct AppClipDefaultExperience: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipDefaultExperienceCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipDefaultExperienceCreateRequest.swift
@@ -43,7 +43,7 @@ public struct AppClipDefaultExperienceCreateRequest: Codable {
 			public struct AppClip: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -87,7 +87,7 @@ public struct AppClipDefaultExperienceCreateRequest: Codable {
 			public struct ReleaseWithAppStoreVersion: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -131,7 +131,7 @@ public struct AppClipDefaultExperienceCreateRequest: Codable {
 			public struct AppClipDefaultExperienceTemplate: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipDefaultExperienceLocalization.swift
+++ b/Sources/OpenAPI/Entities/AppClipDefaultExperienceLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClipDefaultExperienceLocalization: Codable {
+public struct AppClipDefaultExperienceLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -68,7 +68,7 @@ public struct AppClipDefaultExperienceLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -138,7 +138,7 @@ public struct AppClipDefaultExperienceLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipDefaultExperienceLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipDefaultExperienceLocalizationCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppClipDefaultExperienceLocalizationCreateRequest: Codable {
 			public struct AppClipDefaultExperience: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipDefaultExperienceLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipDefaultExperienceLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppClipDefaultExperienceLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse.swift
+++ b/Sources/OpenAPI/Entities/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse.swift
@@ -9,7 +9,7 @@ public struct AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse:
 	public var data: Data
 	public var links: DocumentLinks
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipDefaultExperienceUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipDefaultExperienceUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppClipDefaultExperienceUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -42,7 +42,7 @@ public struct AppClipDefaultExperienceUpdateRequest: Codable {
 			public struct ReleaseWithAppStoreVersion: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipDomainStatus.swift
+++ b/Sources/OpenAPI/Entities/AppClipDomainStatus.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClipDomainStatus: Codable {
+public struct AppClipDomainStatus: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppClipHeaderImage.swift
+++ b/Sources/OpenAPI/Entities/AppClipHeaderImage.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppClipHeaderImage: Codable {
+public struct AppClipHeaderImage: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -83,7 +83,7 @@ public struct AppClipHeaderImage: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipHeaderImageCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipHeaderImageCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppClipHeaderImageCreateRequest: Codable {
 			public struct AppClipDefaultExperienceLocalization: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppClipHeaderImageUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppClipHeaderImageUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppClipHeaderImageUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppCustomProductPage.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPage.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppCustomProductPage: Codable {
+public struct AppCustomProductPage: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -72,7 +72,7 @@ public struct AppCustomProductPage: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -143,7 +143,7 @@ public struct AppCustomProductPage: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppCustomProductPageCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPageCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppCustomProductPageCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -89,7 +89,7 @@ public struct AppCustomProductPageCreateRequest: Codable {
 			public struct AppCustomProductPageVersions: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -133,7 +133,7 @@ public struct AppCustomProductPageCreateRequest: Codable {
 			public struct AppStoreVersionTemplate: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -177,7 +177,7 @@ public struct AppCustomProductPageCreateRequest: Codable {
 			public struct CustomProductPageTemplate: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppCustomProductPageLocalization.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPageLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppCustomProductPageLocalization: Codable {
+public struct AppCustomProductPageLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -69,7 +69,7 @@ public struct AppCustomProductPageLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -140,7 +140,7 @@ public struct AppCustomProductPageLocalization: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -214,7 +214,7 @@ public struct AppCustomProductPageLocalization: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppCustomProductPageLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPageLocalizationCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppCustomProductPageLocalizationCreateRequest: Codable {
 			public struct AppCustomProductPageVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppCustomProductPageLocalizationInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPageLocalizationInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppCustomProductPageLocalizationInlineCreate: Codable {
+public struct AppCustomProductPageLocalizationInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var attributes: Attributes
@@ -43,7 +43,7 @@ public struct AppCustomProductPageLocalizationInlineCreate: Codable {
 		public struct AppCustomProductPageVersion: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppCustomProductPageLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPageLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppCustomProductPageLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppCustomProductPageUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPageUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppCustomProductPageUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppCustomProductPageVersion.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPageVersion.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppCustomProductPageVersion: Codable {
+public struct AppCustomProductPageVersion: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -79,7 +79,7 @@ public struct AppCustomProductPageVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -150,7 +150,7 @@ public struct AppCustomProductPageVersion: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppCustomProductPageVersionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPageVersionCreateRequest.swift
@@ -23,7 +23,7 @@ public struct AppCustomProductPageVersionCreateRequest: Codable {
 			public struct AppCustomProductPage: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -67,7 +67,7 @@ public struct AppCustomProductPageVersionCreateRequest: Codable {
 			public struct AppCustomProductPageLocalizations: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppCustomProductPageVersionInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/AppCustomProductPageVersionInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppCustomProductPageVersionInlineCreate: Codable {
+public struct AppCustomProductPageVersionInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var relationships: Relationships?
@@ -21,7 +21,7 @@ public struct AppCustomProductPageVersionInlineCreate: Codable {
 		public struct AppCustomProductPage: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -65,7 +65,7 @@ public struct AppCustomProductPageVersionInlineCreate: Codable {
 		public struct AppCustomProductPageLocalizations: Codable {
 			public var data: [Datum]?
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEncryptionDeclaration.swift
+++ b/Sources/OpenAPI/Entities/AppEncryptionDeclaration.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppEncryptionDeclaration: Codable {
+public struct AppEncryptionDeclaration: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -107,7 +107,7 @@ public struct AppEncryptionDeclaration: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEncryptionDeclarationBuildsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/AppEncryptionDeclarationBuildsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppEncryptionDeclarationBuildsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEvent.swift
+++ b/Sources/OpenAPI/Entities/AppEvent.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppEvent: Codable {
+public struct AppEvent: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -203,7 +203,7 @@ public struct AppEvent: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEventCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppEventCreateRequest.swift
@@ -129,7 +129,7 @@ public struct AppEventCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEventLocalization.swift
+++ b/Sources/OpenAPI/Entities/AppEventLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppEventLocalization: Codable {
+public struct AppEventLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -77,7 +77,7 @@ public struct AppEventLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -148,7 +148,7 @@ public struct AppEventLocalization: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -222,7 +222,7 @@ public struct AppEventLocalization: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEventLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppEventLocalizationCreateRequest.swift
@@ -53,7 +53,7 @@ public struct AppEventLocalizationCreateRequest: Codable {
 			public struct AppEvent: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEventLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppEventLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppEventLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppEventScreenshot.swift
+++ b/Sources/OpenAPI/Entities/AppEventScreenshot.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppEventScreenshot: Codable {
+public struct AppEventScreenshot: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -87,7 +87,7 @@ public struct AppEventScreenshot: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEventScreenshotCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppEventScreenshotCreateRequest.swift
@@ -49,7 +49,7 @@ public struct AppEventScreenshotCreateRequest: Codable {
 			public struct AppEventLocalization: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEventScreenshotUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppEventScreenshotUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppEventScreenshotUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppEventUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppEventUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppEventUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppEventVideoClip.swift
+++ b/Sources/OpenAPI/Entities/AppEventVideoClip.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppEventVideoClip: Codable {
+public struct AppEventVideoClip: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -91,7 +91,7 @@ public struct AppEventVideoClip: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEventVideoClipCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppEventVideoClipCreateRequest.swift
@@ -53,7 +53,7 @@ public struct AppEventVideoClipCreateRequest: Codable {
 			public struct AppEventLocalization: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppEventVideoClipUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppEventVideoClipUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppEventVideoClipUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppInfo.swift
+++ b/Sources/OpenAPI/Entities/AppInfo.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppInfo: Codable {
+public struct AppInfo: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -83,7 +83,7 @@ public struct AppInfo: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -153,7 +153,7 @@ public struct AppInfo: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -224,7 +224,7 @@ public struct AppInfo: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -297,7 +297,7 @@ public struct AppInfo: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -367,7 +367,7 @@ public struct AppInfo: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -437,7 +437,7 @@ public struct AppInfo: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -507,7 +507,7 @@ public struct AppInfo: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -577,7 +577,7 @@ public struct AppInfo: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -647,7 +647,7 @@ public struct AppInfo: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppInfoLocalization.swift
+++ b/Sources/OpenAPI/Entities/AppInfoLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppInfoLocalization: Codable {
+public struct AppInfoLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -83,7 +83,7 @@ public struct AppInfoLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppInfoLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppInfoLocalizationCreateRequest.swift
@@ -61,7 +61,7 @@ public struct AppInfoLocalizationCreateRequest: Codable {
 			public struct AppInfo: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppInfoLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppInfoLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppInfoLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppInfoUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppInfoUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppInfoUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var relationships: Relationships?
@@ -28,7 +28,7 @@ public struct AppInfoUpdateRequest: Codable {
 			public struct PrimaryCategory: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -72,7 +72,7 @@ public struct AppInfoUpdateRequest: Codable {
 			public struct PrimarySubcategoryOne: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -116,7 +116,7 @@ public struct AppInfoUpdateRequest: Codable {
 			public struct PrimarySubcategoryTwo: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -160,7 +160,7 @@ public struct AppInfoUpdateRequest: Codable {
 			public struct SecondaryCategory: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -204,7 +204,7 @@ public struct AppInfoUpdateRequest: Codable {
 			public struct SecondarySubcategoryOne: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -248,7 +248,7 @@ public struct AppInfoUpdateRequest: Codable {
 			public struct SecondarySubcategoryTwo: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/AppInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppInlineCreate: Codable {
+public struct AppInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var attributes: Attributes
@@ -48,7 +48,7 @@ public struct AppInlineCreate: Codable {
 		public struct AppStoreVersions: Codable {
 			public var data: [Datum]?
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -92,7 +92,7 @@ public struct AppInlineCreate: Codable {
 		public struct AppInfos: Codable {
 			public var data: [Datum]?
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPreOrder.swift
+++ b/Sources/OpenAPI/Entities/AppPreOrder.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppPreOrder: Codable {
+public struct AppPreOrder: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -67,7 +67,7 @@ public struct AppPreOrder: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPreOrderCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppPreOrderCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppPreOrderCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPreOrderUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppPreOrderUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppPreOrderUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppPreview.swift
+++ b/Sources/OpenAPI/Entities/AppPreview.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppPreview: Codable {
+public struct AppPreview: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -95,7 +95,7 @@ public struct AppPreview: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPreviewCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppPreviewCreateRequest.swift
@@ -53,7 +53,7 @@ public struct AppPreviewCreateRequest: Codable {
 			public struct AppPreviewSet: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPreviewSet.swift
+++ b/Sources/OpenAPI/Entities/AppPreviewSet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppPreviewSet: Codable {
+public struct AppPreviewSet: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -66,7 +66,7 @@ public struct AppPreviewSet: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -136,7 +136,7 @@ public struct AppPreviewSet: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -206,7 +206,7 @@ public struct AppPreviewSet: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -277,7 +277,7 @@ public struct AppPreviewSet: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPreviewSetAppPreviewsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/AppPreviewSetAppPreviewsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppPreviewSetAppPreviewsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPreviewSetAppPreviewsLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/AppPreviewSetAppPreviewsLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct AppPreviewSetAppPreviewsLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPreviewSetCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppPreviewSetCreateRequest.swift
@@ -43,7 +43,7 @@ public struct AppPreviewSetCreateRequest: Codable {
 			public struct AppStoreVersionLocalization: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -87,7 +87,7 @@ public struct AppPreviewSetCreateRequest: Codable {
 			public struct AppCustomProductPageLocalization: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -131,7 +131,7 @@ public struct AppPreviewSetCreateRequest: Codable {
 			public struct AppStoreVersionExperimentTreatmentLocalization: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPreviewUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppPreviewUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppPreviewUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppPrice.swift
+++ b/Sources/OpenAPI/Entities/AppPrice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppPrice: Codable {
+public struct AppPrice: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var relationships: Relationships?
@@ -45,7 +45,7 @@ public struct AppPrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -115,7 +115,7 @@ public struct AppPrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPriceInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/AppPriceInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppPriceInlineCreate: Codable {
+public struct AppPriceInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 

--- a/Sources/OpenAPI/Entities/AppPricePoint.swift
+++ b/Sources/OpenAPI/Entities/AppPricePoint.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 @available(*, deprecated, message: "Deprecated")
-public struct AppPricePoint: Codable {
+public struct AppPricePoint: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -69,7 +69,7 @@ public struct AppPricePoint: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -139,7 +139,7 @@ public struct AppPricePoint: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPricePointV2.swift
+++ b/Sources/OpenAPI/Entities/AppPricePointV2.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppPricePointV2: Codable {
+public struct AppPricePointV2: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -69,7 +69,7 @@ public struct AppPricePointV2: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -139,7 +139,7 @@ public struct AppPricePointV2: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -209,7 +209,7 @@ public struct AppPricePointV2: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPriceTier.swift
+++ b/Sources/OpenAPI/Entities/AppPriceTier.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppPriceTier: Codable {
+public struct AppPriceTier: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var relationships: Relationships?
@@ -47,7 +47,7 @@ public struct AppPriceTier: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPromotedPurchasesLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/AppPromotedPurchasesLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppPromotedPurchasesLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppPromotedPurchasesLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/AppPromotedPurchasesLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct AppPromotedPurchasesLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppScreenshot.swift
+++ b/Sources/OpenAPI/Entities/AppScreenshot.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppScreenshot: Codable {
+public struct AppScreenshot: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -91,7 +91,7 @@ public struct AppScreenshot: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppScreenshotCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppScreenshotCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppScreenshotCreateRequest: Codable {
 			public struct AppScreenshotSet: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppScreenshotSet.swift
+++ b/Sources/OpenAPI/Entities/AppScreenshotSet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppScreenshotSet: Codable {
+public struct AppScreenshotSet: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -66,7 +66,7 @@ public struct AppScreenshotSet: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -136,7 +136,7 @@ public struct AppScreenshotSet: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -206,7 +206,7 @@ public struct AppScreenshotSet: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -277,7 +277,7 @@ public struct AppScreenshotSet: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppScreenshotSetAppScreenshotsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/AppScreenshotSetAppScreenshotsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppScreenshotSetAppScreenshotsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppScreenshotSetAppScreenshotsLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/AppScreenshotSetAppScreenshotsLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct AppScreenshotSetAppScreenshotsLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppScreenshotSetCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppScreenshotSetCreateRequest.swift
@@ -43,7 +43,7 @@ public struct AppScreenshotSetCreateRequest: Codable {
 			public struct AppStoreVersionLocalization: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -87,7 +87,7 @@ public struct AppScreenshotSetCreateRequest: Codable {
 			public struct AppCustomProductPageLocalization: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -131,7 +131,7 @@ public struct AppScreenshotSetCreateRequest: Codable {
 			public struct AppStoreVersionExperimentTreatmentLocalization: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppScreenshotUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppScreenshotUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppScreenshotUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppStoreReviewAttachment.swift
+++ b/Sources/OpenAPI/Entities/AppStoreReviewAttachment.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreReviewAttachment: Codable {
+public struct AppStoreReviewAttachment: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -79,7 +79,7 @@ public struct AppStoreReviewAttachment: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreReviewAttachmentCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreReviewAttachmentCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppStoreReviewAttachmentCreateRequest: Codable {
 			public struct AppStoreReviewDetail: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreReviewAttachmentUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreReviewAttachmentUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppStoreReviewAttachmentUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppStoreReviewDetail.swift
+++ b/Sources/OpenAPI/Entities/AppStoreReviewDetail.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreReviewDetail: Codable {
+public struct AppStoreReviewDetail: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -92,7 +92,7 @@ public struct AppStoreReviewDetail: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -163,7 +163,7 @@ public struct AppStoreReviewDetail: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreReviewDetailCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreReviewDetailCreateRequest.swift
@@ -69,7 +69,7 @@ public struct AppStoreReviewDetailCreateRequest: Codable {
 			public struct AppStoreVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreReviewDetailUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreReviewDetailUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppStoreReviewDetailUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppStoreVersion.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersion.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreVersion: Codable {
+public struct AppStoreVersion: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -107,7 +107,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -178,7 +178,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -249,7 +249,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -322,7 +322,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -392,7 +392,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -462,7 +462,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -532,7 +532,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -602,7 +602,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -672,7 +672,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -743,7 +743,7 @@ public struct AppStoreVersion: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionAppClipDefaultExperienceLinkageRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionAppClipDefaultExperienceLinkageRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppStoreVersionAppClipDefaultExperienceLinkageRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionAppClipDefaultExperienceLinkageResponse.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionAppClipDefaultExperienceLinkageResponse.swift
@@ -9,7 +9,7 @@ public struct AppStoreVersionAppClipDefaultExperienceLinkageResponse: Codable {
 	public var data: Data
 	public var links: DocumentLinks
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionBuildLinkageRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionBuildLinkageRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppStoreVersionBuildLinkageRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionBuildLinkageResponse.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionBuildLinkageResponse.swift
@@ -9,7 +9,7 @@ public struct AppStoreVersionBuildLinkageResponse: Codable {
 	public var data: Data
 	public var links: DocumentLinks
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionCreateRequest.swift
@@ -65,7 +65,7 @@ public struct AppStoreVersionCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -109,7 +109,7 @@ public struct AppStoreVersionCreateRequest: Codable {
 			public struct AppStoreVersionLocalizations: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -153,7 +153,7 @@ public struct AppStoreVersionCreateRequest: Codable {
 			public struct Build: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionExperiment.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionExperiment.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreVersionExperiment: Codable {
+public struct AppStoreVersionExperiment: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -96,7 +96,7 @@ public struct AppStoreVersionExperiment: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -167,7 +167,7 @@ public struct AppStoreVersionExperiment: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionExperimentCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionExperimentCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppStoreVersionExperimentCreateRequest: Codable {
 			public struct AppStoreVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatment.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatment.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreVersionExperimentTreatment: Codable {
+public struct AppStoreVersionExperimentTreatment: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -76,7 +76,7 @@ public struct AppStoreVersionExperimentTreatment: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -147,7 +147,7 @@ public struct AppStoreVersionExperimentTreatment: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatmentCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatmentCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppStoreVersionExperimentTreatmentCreateRequest: Codable {
 			public struct AppStoreVersionExperiment: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatmentLocalization.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatmentLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreVersionExperimentTreatmentLocalization: Codable {
+public struct AppStoreVersionExperimentTreatmentLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -65,7 +65,7 @@ public struct AppStoreVersionExperimentTreatmentLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -136,7 +136,7 @@ public struct AppStoreVersionExperimentTreatmentLocalization: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -210,7 +210,7 @@ public struct AppStoreVersionExperimentTreatmentLocalization: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatmentLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatmentLocalizationCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppStoreVersionExperimentTreatmentLocalizationCreateRequest: Codab
 			public struct AppStoreVersionExperimentTreatment: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatmentUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionExperimentTreatmentUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppStoreVersionExperimentTreatmentUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppStoreVersionExperimentUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionExperimentUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppStoreVersionExperimentUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppStoreVersionLocalization.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreVersionLocalization: Codable {
+public struct AppStoreVersionLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -89,7 +89,7 @@ public struct AppStoreVersionLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -160,7 +160,7 @@ public struct AppStoreVersionLocalization: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -234,7 +234,7 @@ public struct AppStoreVersionLocalization: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionLocalizationCreateRequest.swift
@@ -65,7 +65,7 @@ public struct AppStoreVersionLocalizationCreateRequest: Codable {
 			public struct AppStoreVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppStoreVersionLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppStoreVersionPhasedRelease.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionPhasedRelease.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreVersionPhasedRelease: Codable {
+public struct AppStoreVersionPhasedRelease: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppStoreVersionPhasedReleaseCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionPhasedReleaseCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppStoreVersionPhasedReleaseCreateRequest: Codable {
 			public struct AppStoreVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionPhasedReleaseUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionPhasedReleaseUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppStoreVersionPhasedReleaseUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/AppStoreVersionPromotion.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionPromotion.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreVersionPromotion: Codable {
+public struct AppStoreVersionPromotion: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var links: ResourceLinks

--- a/Sources/OpenAPI/Entities/AppStoreVersionPromotionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionPromotionCreateRequest.swift
@@ -23,7 +23,7 @@ public struct AppStoreVersionPromotionCreateRequest: Codable {
 			public struct AppStoreVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -67,7 +67,7 @@ public struct AppStoreVersionPromotionCreateRequest: Codable {
 			public struct AppStoreVersionExperimentTreatment: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionReleaseRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionReleaseRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct AppStoreVersionReleaseRequest: Codable {
+public struct AppStoreVersionReleaseRequest: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var links: ResourceLinks

--- a/Sources/OpenAPI/Entities/AppStoreVersionReleaseRequestCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionReleaseRequestCreateRequest.swift
@@ -22,7 +22,7 @@ public struct AppStoreVersionReleaseRequestCreateRequest: Codable {
 			public struct AppStoreVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionSubmission.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionSubmission.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 @available(*, deprecated, message: "Deprecated")
-public struct AppStoreVersionSubmission: Codable {
+public struct AppStoreVersionSubmission: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var relationships: Relationships?
@@ -45,7 +45,7 @@ public struct AppStoreVersionSubmission: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionSubmissionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionSubmissionCreateRequest.swift
@@ -23,7 +23,7 @@ public struct AppStoreVersionSubmissionCreateRequest: Codable {
 			public struct AppStoreVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppStoreVersionUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppStoreVersionUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppStoreVersionUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -65,7 +65,7 @@ public struct AppStoreVersionUpdateRequest: Codable {
 			public struct Build: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -109,7 +109,7 @@ public struct AppStoreVersionUpdateRequest: Codable {
 			public struct AppClipDefaultExperience: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/AppUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/AppUpdateRequest.swift
@@ -9,7 +9,7 @@ public struct AppUpdateRequest: Codable {
 	public var data: Data
 	public var included: [AppPriceInlineCreate]?
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -77,7 +77,7 @@ public struct AppUpdateRequest: Codable {
 			public struct Prices: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -121,7 +121,7 @@ public struct AppUpdateRequest: Codable {
 			public struct AvailableTerritories: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaAppClipInvocation.swift
+++ b/Sources/OpenAPI/Entities/BetaAppClipInvocation.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaAppClipInvocation: Codable {
+public struct BetaAppClipInvocation: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -64,7 +64,7 @@ public struct BetaAppClipInvocation: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaAppClipInvocationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaAppClipInvocationCreateRequest.swift
@@ -43,7 +43,7 @@ public struct BetaAppClipInvocationCreateRequest: Codable {
 			public struct BuildBundle: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -87,7 +87,7 @@ public struct BetaAppClipInvocationCreateRequest: Codable {
 			public struct BetaAppClipInvocationLocalizations: Codable {
 				public var data: [Datum]
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaAppClipInvocationLocalization.swift
+++ b/Sources/OpenAPI/Entities/BetaAppClipInvocationLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaAppClipInvocationLocalization: Codable {
+public struct BetaAppClipInvocationLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BetaAppClipInvocationLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaAppClipInvocationLocalizationCreateRequest.swift
@@ -45,7 +45,7 @@ public struct BetaAppClipInvocationLocalizationCreateRequest: Codable {
 			public struct BetaAppClipInvocation: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaAppClipInvocationLocalizationInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/BetaAppClipInvocationLocalizationInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaAppClipInvocationLocalizationInlineCreate: Codable {
+public struct BetaAppClipInvocationLocalizationInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var attributes: Attributes
@@ -43,7 +43,7 @@ public struct BetaAppClipInvocationLocalizationInlineCreate: Codable {
 		public struct BetaAppClipInvocation: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaAppClipInvocationLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaAppClipInvocationLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaAppClipInvocationLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BetaAppClipInvocationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaAppClipInvocationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaAppClipInvocationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BetaAppLocalization.swift
+++ b/Sources/OpenAPI/Entities/BetaAppLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaAppLocalization: Codable {
+public struct BetaAppLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -83,7 +83,7 @@ public struct BetaAppLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaAppLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaAppLocalizationCreateRequest.swift
@@ -61,7 +61,7 @@ public struct BetaAppLocalizationCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaAppLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaAppLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaAppLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BetaAppReviewDetail.swift
+++ b/Sources/OpenAPI/Entities/BetaAppReviewDetail.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaAppReviewDetail: Codable {
+public struct BetaAppReviewDetail: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -91,7 +91,7 @@ public struct BetaAppReviewDetail: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaAppReviewDetailUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaAppReviewDetailUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaAppReviewDetailUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BetaAppReviewSubmission.swift
+++ b/Sources/OpenAPI/Entities/BetaAppReviewSubmission.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaAppReviewSubmission: Codable {
+public struct BetaAppReviewSubmission: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -67,7 +67,7 @@ public struct BetaAppReviewSubmission: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaAppReviewSubmissionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaAppReviewSubmissionCreateRequest.swift
@@ -22,7 +22,7 @@ public struct BetaAppReviewSubmissionCreateRequest: Codable {
 			public struct Build: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaBuildLocalization.swift
+++ b/Sources/OpenAPI/Entities/BetaBuildLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaBuildLocalization: Codable {
+public struct BetaBuildLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -67,7 +67,7 @@ public struct BetaBuildLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaBuildLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaBuildLocalizationCreateRequest.swift
@@ -45,7 +45,7 @@ public struct BetaBuildLocalizationCreateRequest: Codable {
 			public struct Build: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaBuildLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaBuildLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaBuildLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BetaGroup.swift
+++ b/Sources/OpenAPI/Entities/BetaGroup.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaGroup: Codable {
+public struct BetaGroup: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -105,7 +105,7 @@ public struct BetaGroup: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -176,7 +176,7 @@ public struct BetaGroup: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -250,7 +250,7 @@ public struct BetaGroup: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaGroupBetaTestersLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaGroupBetaTestersLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaGroupBetaTestersLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaGroupBetaTestersLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/BetaGroupBetaTestersLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct BetaGroupBetaTestersLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaGroupBuildsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaGroupBuildsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaGroupBuildsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaGroupBuildsLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/BetaGroupBuildsLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct BetaGroupBuildsLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaGroupCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaGroupCreateRequest.swift
@@ -67,7 +67,7 @@ public struct BetaGroupCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -111,7 +111,7 @@ public struct BetaGroupCreateRequest: Codable {
 			public struct Builds: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -155,7 +155,7 @@ public struct BetaGroupCreateRequest: Codable {
 			public struct BetaTesters: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaGroupUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaGroupUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaGroupUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BetaLicenseAgreement.swift
+++ b/Sources/OpenAPI/Entities/BetaLicenseAgreement.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaLicenseAgreement: Codable {
+public struct BetaLicenseAgreement: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -63,7 +63,7 @@ public struct BetaLicenseAgreement: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaLicenseAgreementUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaLicenseAgreementUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaLicenseAgreementUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BetaTester.swift
+++ b/Sources/OpenAPI/Entities/BetaTester.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaTester: Codable {
+public struct BetaTester: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -78,7 +78,7 @@ public struct BetaTester: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -152,7 +152,7 @@ public struct BetaTester: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -226,7 +226,7 @@ public struct BetaTester: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaTesterAppsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaTesterAppsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaTesterAppsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaTesterAppsLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/BetaTesterAppsLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct BetaTesterAppsLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaTesterBetaGroupsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaTesterBetaGroupsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaTesterBetaGroupsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaTesterBetaGroupsLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/BetaTesterBetaGroupsLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct BetaTesterBetaGroupsLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaTesterBuildsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaTesterBuildsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BetaTesterBuildsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaTesterBuildsLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/BetaTesterBuildsLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct BetaTesterBuildsLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaTesterCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaTesterCreateRequest.swift
@@ -50,7 +50,7 @@ public struct BetaTesterCreateRequest: Codable {
 			public struct BetaGroups: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -94,7 +94,7 @@ public struct BetaTesterCreateRequest: Codable {
 			public struct Builds: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BetaTesterInvitation.swift
+++ b/Sources/OpenAPI/Entities/BetaTesterInvitation.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BetaTesterInvitation: Codable {
+public struct BetaTesterInvitation: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var links: ResourceLinks

--- a/Sources/OpenAPI/Entities/BetaTesterInvitationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BetaTesterInvitationCreateRequest.swift
@@ -23,7 +23,7 @@ public struct BetaTesterInvitationCreateRequest: Codable {
 			public struct BetaTester: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -67,7 +67,7 @@ public struct BetaTesterInvitationCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/Build.swift
+++ b/Sources/OpenAPI/Entities/Build.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct Build: Codable {
+public struct Build: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -120,7 +120,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -191,7 +191,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -265,7 +265,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -339,7 +339,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -412,7 +412,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -482,7 +482,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -552,7 +552,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -622,7 +622,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -692,7 +692,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -763,7 +763,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -837,7 +837,7 @@ public struct Build: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BuildAppEncryptionDeclarationLinkageRequest.swift
+++ b/Sources/OpenAPI/Entities/BuildAppEncryptionDeclarationLinkageRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BuildAppEncryptionDeclarationLinkageRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BuildAppEncryptionDeclarationLinkageResponse.swift
+++ b/Sources/OpenAPI/Entities/BuildAppEncryptionDeclarationLinkageResponse.swift
@@ -9,7 +9,7 @@ public struct BuildAppEncryptionDeclarationLinkageResponse: Codable {
 	public var data: Data
 	public var links: DocumentLinks
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BuildBetaDetail.swift
+++ b/Sources/OpenAPI/Entities/BuildBetaDetail.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BuildBetaDetail: Codable {
+public struct BuildBetaDetail: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -71,7 +71,7 @@ public struct BuildBetaDetail: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BuildBetaDetailUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BuildBetaDetailUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BuildBetaDetailUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BuildBetaGroupsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/BuildBetaGroupsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BuildBetaGroupsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BuildBetaNotification.swift
+++ b/Sources/OpenAPI/Entities/BuildBetaNotification.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BuildBetaNotification: Codable {
+public struct BuildBetaNotification: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var links: ResourceLinks

--- a/Sources/OpenAPI/Entities/BuildBetaNotificationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BuildBetaNotificationCreateRequest.swift
@@ -22,7 +22,7 @@ public struct BuildBetaNotificationCreateRequest: Codable {
 			public struct Build: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BuildBundle.swift
+++ b/Sources/OpenAPI/Entities/BuildBundle.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BuildBundle: Codable {
+public struct BuildBundle: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -135,7 +135,7 @@ public struct BuildBundle: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -205,7 +205,7 @@ public struct BuildBundle: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -276,7 +276,7 @@ public struct BuildBundle: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -350,7 +350,7 @@ public struct BuildBundle: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BuildBundleFileSize.swift
+++ b/Sources/OpenAPI/Entities/BuildBundleFileSize.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BuildBundleFileSize: Codable {
+public struct BuildBundleFileSize: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BuildIcon.swift
+++ b/Sources/OpenAPI/Entities/BuildIcon.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BuildIcon: Codable {
+public struct BuildIcon: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BuildIndividualTestersLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/BuildIndividualTestersLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BuildIndividualTestersLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BuildIndividualTestersLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/BuildIndividualTestersLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct BuildIndividualTestersLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/BuildUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BuildUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BuildUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -46,7 +46,7 @@ public struct BuildUpdateRequest: Codable {
 			public struct AppEncryptionDeclaration: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BundleID.swift
+++ b/Sources/OpenAPI/Entities/BundleID.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BundleID: Codable {
+public struct BundleID: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -78,7 +78,7 @@ public struct BundleID: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -152,7 +152,7 @@ public struct BundleID: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -225,7 +225,7 @@ public struct BundleID: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/BundleIDCapability.swift
+++ b/Sources/OpenAPI/Entities/BundleIDCapability.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct BundleIDCapability: Codable {
+public struct BundleIDCapability: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BundleIDCapabilityCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/BundleIDCapabilityCreateRequest.swift
@@ -45,7 +45,7 @@ public struct BundleIDCapabilityCreateRequest: Codable {
 			public struct BundleID: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/BundleIDCapabilityUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BundleIDCapabilityUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BundleIDCapabilityUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/BundleIDUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/BundleIDUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct BundleIDUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/Certificate.swift
+++ b/Sources/OpenAPI/Entities/Certificate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct Certificate: Codable {
+public struct Certificate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/CiArtifact.swift
+++ b/Sources/OpenAPI/Entities/CiArtifact.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CiArtifact: Codable {
+public struct CiArtifact: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/CiBuildAction.swift
+++ b/Sources/OpenAPI/Entities/CiBuildAction.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CiBuildAction: Codable {
+public struct CiBuildAction: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -91,7 +91,7 @@ public struct CiBuildAction: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/CiBuildRun.swift
+++ b/Sources/OpenAPI/Entities/CiBuildRun.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CiBuildRun: Codable {
+public struct CiBuildRun: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -195,7 +195,7 @@ public struct CiBuildRun: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -268,7 +268,7 @@ public struct CiBuildRun: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -338,7 +338,7 @@ public struct CiBuildRun: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -408,7 +408,7 @@ public struct CiBuildRun: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -478,7 +478,7 @@ public struct CiBuildRun: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -548,7 +548,7 @@ public struct CiBuildRun: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/CiBuildRunCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/CiBuildRunCreateRequest.swift
@@ -44,7 +44,7 @@ public struct CiBuildRunCreateRequest: Codable {
 			public struct BuildRun: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -88,7 +88,7 @@ public struct CiBuildRunCreateRequest: Codable {
 			public struct Workflow: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -132,7 +132,7 @@ public struct CiBuildRunCreateRequest: Codable {
 			public struct SourceBranchOrTag: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -176,7 +176,7 @@ public struct CiBuildRunCreateRequest: Codable {
 			public struct PullRequest: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/CiIssue.swift
+++ b/Sources/OpenAPI/Entities/CiIssue.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CiIssue: Codable {
+public struct CiIssue: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/CiMacOsVersion.swift
+++ b/Sources/OpenAPI/Entities/CiMacOsVersion.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CiMacOsVersion: Codable {
+public struct CiMacOsVersion: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -68,7 +68,7 @@ public struct CiMacOsVersion: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/CiProduct.swift
+++ b/Sources/OpenAPI/Entities/CiProduct.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CiProduct: Codable {
+public struct CiProduct: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -78,7 +78,7 @@ public struct CiProduct: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -148,7 +148,7 @@ public struct CiProduct: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -219,7 +219,7 @@ public struct CiProduct: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/CiTestResult.swift
+++ b/Sources/OpenAPI/Entities/CiTestResult.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CiTestResult: Codable {
+public struct CiTestResult: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/CiWorkflow.swift
+++ b/Sources/OpenAPI/Entities/CiWorkflow.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CiWorkflow: Codable {
+public struct CiWorkflow: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -110,7 +110,7 @@ public struct CiWorkflow: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -180,7 +180,7 @@ public struct CiWorkflow: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -250,7 +250,7 @@ public struct CiWorkflow: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -320,7 +320,7 @@ public struct CiWorkflow: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/CiWorkflowCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/CiWorkflowCreateRequest.swift
@@ -84,7 +84,7 @@ public struct CiWorkflowCreateRequest: Codable {
 			public struct Product: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -128,7 +128,7 @@ public struct CiWorkflowCreateRequest: Codable {
 			public struct Repository: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -172,7 +172,7 @@ public struct CiWorkflowCreateRequest: Codable {
 			public struct XcodeVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -216,7 +216,7 @@ public struct CiWorkflowCreateRequest: Codable {
 			public struct MacOsVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/CiWorkflowUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/CiWorkflowUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct CiWorkflowUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -83,7 +83,7 @@ public struct CiWorkflowUpdateRequest: Codable {
 			public struct XcodeVersion: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -127,7 +127,7 @@ public struct CiWorkflowUpdateRequest: Codable {
 			public struct MacOsVersion: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/CiXcodeVersion.swift
+++ b/Sources/OpenAPI/Entities/CiXcodeVersion.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CiXcodeVersion: Codable {
+public struct CiXcodeVersion: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -124,7 +124,7 @@ public struct CiXcodeVersion: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/CustomerReview.swift
+++ b/Sources/OpenAPI/Entities/CustomerReview.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CustomerReview: Codable {
+public struct CustomerReview: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -83,7 +83,7 @@ public struct CustomerReview: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/CustomerReviewResponseV1.swift
+++ b/Sources/OpenAPI/Entities/CustomerReviewResponseV1.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct CustomerReviewResponseV1: Codable {
+public struct CustomerReviewResponseV1: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -76,7 +76,7 @@ public struct CustomerReviewResponseV1: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/CustomerReviewResponseV1CreateRequest.swift
+++ b/Sources/OpenAPI/Entities/CustomerReviewResponseV1CreateRequest.swift
@@ -41,7 +41,7 @@ public struct CustomerReviewResponseV1CreateRequest: Codable {
 			public struct Review: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/Device.swift
+++ b/Sources/OpenAPI/Entities/Device.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct Device: Codable {
+public struct Device: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/DeviceUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/DeviceUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct DeviceUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/DiagnosticLog.swift
+++ b/Sources/OpenAPI/Entities/DiagnosticLog.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct DiagnosticLog: Codable {
+public struct DiagnosticLog: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var links: ResourceLinks

--- a/Sources/OpenAPI/Entities/DiagnosticSignature.swift
+++ b/Sources/OpenAPI/Entities/DiagnosticSignature.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct DiagnosticSignature: Codable {
+public struct DiagnosticSignature: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/EndUserLicenseAgreement.swift
+++ b/Sources/OpenAPI/Entities/EndUserLicenseAgreement.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct EndUserLicenseAgreement: Codable {
+public struct EndUserLicenseAgreement: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -64,7 +64,7 @@ public struct EndUserLicenseAgreement: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -135,7 +135,7 @@ public struct EndUserLicenseAgreement: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/EndUserLicenseAgreementCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/EndUserLicenseAgreementCreateRequest.swift
@@ -42,7 +42,7 @@ public struct EndUserLicenseAgreementCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -86,7 +86,7 @@ public struct EndUserLicenseAgreementCreateRequest: Codable {
 			public struct Territories: Codable {
 				public var data: [Datum]
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/EndUserLicenseAgreementUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/EndUserLicenseAgreementUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct EndUserLicenseAgreementUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -42,7 +42,7 @@ public struct EndUserLicenseAgreementUpdateRequest: Codable {
 			public struct Territories: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/ErrorResponse.swift
+++ b/Sources/OpenAPI/Entities/ErrorResponse.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct ErrorResponse: Codable {
 	public var errors: [Error]?
 
-	public struct Error: Codable {
+	public struct Error: Codable, Identifiable {
 		public var id: String?
 		public var status: String
 		public var code: String

--- a/Sources/OpenAPI/Entities/GameCenterEnabledVersion.swift
+++ b/Sources/OpenAPI/Entities/GameCenterEnabledVersion.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct GameCenterEnabledVersion: Codable {
+public struct GameCenterEnabledVersion: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -73,7 +73,7 @@ public struct GameCenterEnabledVersion: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -146,7 +146,7 @@ public struct GameCenterEnabledVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/GameCenterEnabledVersionCompatibleVersionsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/GameCenterEnabledVersionCompatibleVersionsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct GameCenterEnabledVersionCompatibleVersionsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/GameCenterEnabledVersionCompatibleVersionsLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/GameCenterEnabledVersionCompatibleVersionsLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct GameCenterEnabledVersionCompatibleVersionsLinkagesResponse: Codabl
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchase.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchase.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchase: Codable {
+public struct InAppPurchase: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -106,7 +106,7 @@ public struct InAppPurchase: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseAppStoreReviewScreenshot.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseAppStoreReviewScreenshot.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchaseAppStoreReviewScreenshot: Codable {
+public struct InAppPurchaseAppStoreReviewScreenshot: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -91,7 +91,7 @@ public struct InAppPurchaseAppStoreReviewScreenshot: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseAppStoreReviewScreenshotCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseAppStoreReviewScreenshotCreateRequest.swift
@@ -45,7 +45,7 @@ public struct InAppPurchaseAppStoreReviewScreenshotCreateRequest: Codable {
 			public struct InAppPurchaseV2: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseAppStoreReviewScreenshotUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseAppStoreReviewScreenshotUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct InAppPurchaseAppStoreReviewScreenshotUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/InAppPurchaseContent.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseContent.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchaseContent: Codable {
+public struct InAppPurchaseContent: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -75,7 +75,7 @@ public struct InAppPurchaseContent: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseLocalization.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchaseLocalization: Codable {
+public struct InAppPurchaseLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -82,7 +82,7 @@ public struct InAppPurchaseLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseLocalizationCreateRequest.swift
@@ -49,7 +49,7 @@ public struct InAppPurchaseLocalizationCreateRequest: Codable {
 			public struct InAppPurchaseV2: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct InAppPurchaseLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/InAppPurchasePrice.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchasePrice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchasePrice: Codable {
+public struct InAppPurchasePrice: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -64,7 +64,7 @@ public struct InAppPurchasePrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -134,7 +134,7 @@ public struct InAppPurchasePrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchasePriceInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchasePriceInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchasePriceInlineCreate: Codable {
+public struct InAppPurchasePriceInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var attributes: Attributes?
@@ -40,7 +40,7 @@ public struct InAppPurchasePriceInlineCreate: Codable {
 		public struct InAppPurchaseV2: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -84,7 +84,7 @@ public struct InAppPurchasePriceInlineCreate: Codable {
 		public struct InAppPurchasePricePoint: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchasePricePoint.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchasePricePoint.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchasePricePoint: Codable {
+public struct InAppPurchasePricePoint: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -71,7 +71,7 @@ public struct InAppPurchasePricePoint: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchasePriceSchedule.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchasePriceSchedule.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchasePriceSchedule: Codable {
+public struct InAppPurchasePriceSchedule: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var relationships: Relationships?
@@ -45,7 +45,7 @@ public struct InAppPurchasePriceSchedule: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -116,7 +116,7 @@ public struct InAppPurchasePriceSchedule: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchasePriceScheduleCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchasePriceScheduleCreateRequest.swift
@@ -24,7 +24,7 @@ public struct InAppPurchasePriceScheduleCreateRequest: Codable {
 			public struct InAppPurchase: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -68,7 +68,7 @@ public struct InAppPurchasePriceScheduleCreateRequest: Codable {
 			public struct ManualPrices: Codable {
 				public var data: [Datum]
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseSubmission.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseSubmission.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchaseSubmission: Codable {
+public struct InAppPurchaseSubmission: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var relationships: Relationships?
@@ -44,7 +44,7 @@ public struct InAppPurchaseSubmission: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseSubmissionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseSubmissionCreateRequest.swift
@@ -22,7 +22,7 @@ public struct InAppPurchaseSubmissionCreateRequest: Codable {
 			public struct InAppPurchaseV2: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseV2.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseV2.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct InAppPurchaseV2: Codable {
+public struct InAppPurchaseV2: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -97,7 +97,7 @@ public struct InAppPurchaseV2: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -171,7 +171,7 @@ public struct InAppPurchaseV2: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -244,7 +244,7 @@ public struct InAppPurchaseV2: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -314,7 +314,7 @@ public struct InAppPurchaseV2: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -384,7 +384,7 @@ public struct InAppPurchaseV2: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -454,7 +454,7 @@ public struct InAppPurchaseV2: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseV2CreateRequest.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseV2CreateRequest.swift
@@ -61,7 +61,7 @@ public struct InAppPurchaseV2CreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/InAppPurchaseV2UpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/InAppPurchaseV2UpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct InAppPurchaseV2UpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/PerfPowerMetric.swift
+++ b/Sources/OpenAPI/Entities/PerfPowerMetric.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct PerfPowerMetric: Codable {
+public struct PerfPowerMetric: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/PrereleaseVersion.swift
+++ b/Sources/OpenAPI/Entities/PrereleaseVersion.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct PrereleaseVersion: Codable {
+public struct PrereleaseVersion: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -69,7 +69,7 @@ public struct PrereleaseVersion: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -142,7 +142,7 @@ public struct PrereleaseVersion: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/Profile.swift
+++ b/Sources/OpenAPI/Entities/Profile.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct Profile: Codable {
+public struct Profile: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -115,7 +115,7 @@ public struct Profile: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -186,7 +186,7 @@ public struct Profile: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -260,7 +260,7 @@ public struct Profile: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/ProfileCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/ProfileCreateRequest.swift
@@ -64,7 +64,7 @@ public struct ProfileCreateRequest: Codable {
 			public struct BundleID: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -108,7 +108,7 @@ public struct ProfileCreateRequest: Codable {
 			public struct Devices: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -152,7 +152,7 @@ public struct ProfileCreateRequest: Codable {
 			public struct Certificates: Codable {
 				public var data: [Datum]
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/PromotedPurchase.swift
+++ b/Sources/OpenAPI/Entities/PromotedPurchase.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct PromotedPurchase: Codable {
+public struct PromotedPurchase: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -80,7 +80,7 @@ public struct PromotedPurchase: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -150,7 +150,7 @@ public struct PromotedPurchase: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -221,7 +221,7 @@ public struct PromotedPurchase: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/PromotedPurchaseCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/PromotedPurchaseCreateRequest.swift
@@ -47,7 +47,7 @@ public struct PromotedPurchaseCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -91,7 +91,7 @@ public struct PromotedPurchaseCreateRequest: Codable {
 			public struct InAppPurchaseV2: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -135,7 +135,7 @@ public struct PromotedPurchaseCreateRequest: Codable {
 			public struct Subscription: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/PromotedPurchaseImage.swift
+++ b/Sources/OpenAPI/Entities/PromotedPurchaseImage.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct PromotedPurchaseImage: Codable {
+public struct PromotedPurchaseImage: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -101,7 +101,7 @@ public struct PromotedPurchaseImage: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/PromotedPurchaseImageCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/PromotedPurchaseImageCreateRequest.swift
@@ -45,7 +45,7 @@ public struct PromotedPurchaseImageCreateRequest: Codable {
 			public struct PromotedPurchase: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/PromotedPurchaseImageUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/PromotedPurchaseImageUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct PromotedPurchaseImageUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/PromotedPurchaseUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/PromotedPurchaseUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct PromotedPurchaseUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/ReviewSubmission.swift
+++ b/Sources/OpenAPI/Entities/ReviewSubmission.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct ReviewSubmission: Codable {
+public struct ReviewSubmission: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -83,7 +83,7 @@ public struct ReviewSubmission: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -154,7 +154,7 @@ public struct ReviewSubmission: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -227,7 +227,7 @@ public struct ReviewSubmission: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/ReviewSubmissionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/ReviewSubmissionCreateRequest.swift
@@ -41,7 +41,7 @@ public struct ReviewSubmissionCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/ReviewSubmissionItem.swift
+++ b/Sources/OpenAPI/Entities/ReviewSubmissionItem.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct ReviewSubmissionItem: Codable {
+public struct ReviewSubmissionItem: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -74,7 +74,7 @@ public struct ReviewSubmissionItem: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -144,7 +144,7 @@ public struct ReviewSubmissionItem: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -214,7 +214,7 @@ public struct ReviewSubmissionItem: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -284,7 +284,7 @@ public struct ReviewSubmissionItem: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/ReviewSubmissionItemCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/ReviewSubmissionItemCreateRequest.swift
@@ -26,7 +26,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable {
 			public struct ReviewSubmission: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -70,7 +70,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable {
 			public struct AppStoreVersion: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -114,7 +114,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable {
 			public struct AppCustomProductPageVersion: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -158,7 +158,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable {
 			public struct AppStoreVersionExperiment: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -202,7 +202,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable {
 			public struct AppEvent: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/ReviewSubmissionItemUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/ReviewSubmissionItemUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct ReviewSubmissionItemUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/ReviewSubmissionUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/ReviewSubmissionUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct ReviewSubmissionUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/RoutingAppCoverage.swift
+++ b/Sources/OpenAPI/Entities/RoutingAppCoverage.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct RoutingAppCoverage: Codable {
+public struct RoutingAppCoverage: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -79,7 +79,7 @@ public struct RoutingAppCoverage: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/RoutingAppCoverageCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/RoutingAppCoverageCreateRequest.swift
@@ -45,7 +45,7 @@ public struct RoutingAppCoverageCreateRequest: Codable {
 			public struct AppStoreVersion: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/RoutingAppCoverageUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/RoutingAppCoverageUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct RoutingAppCoverageUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/ScmGitReference.swift
+++ b/Sources/OpenAPI/Entities/ScmGitReference.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct ScmGitReference: Codable {
+public struct ScmGitReference: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -75,7 +75,7 @@ public struct ScmGitReference: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/ScmProvider.swift
+++ b/Sources/OpenAPI/Entities/ScmProvider.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct ScmProvider: Codable {
+public struct ScmProvider: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/ScmPullRequest.swift
+++ b/Sources/OpenAPI/Entities/ScmPullRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct ScmPullRequest: Codable {
+public struct ScmPullRequest: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -103,7 +103,7 @@ public struct ScmPullRequest: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/ScmRepository.swift
+++ b/Sources/OpenAPI/Entities/ScmRepository.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct ScmRepository: Codable {
+public struct ScmRepository: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -80,7 +80,7 @@ public struct ScmRepository: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -150,7 +150,7 @@ public struct ScmRepository: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/Subscription.swift
+++ b/Sources/OpenAPI/Entities/Subscription.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct Subscription: Codable {
+public struct Subscription: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -121,7 +121,7 @@ public struct Subscription: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -194,7 +194,7 @@ public struct Subscription: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -264,7 +264,7 @@ public struct Subscription: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -335,7 +335,7 @@ public struct Subscription: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -409,7 +409,7 @@ public struct Subscription: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -483,7 +483,7 @@ public struct Subscription: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -557,7 +557,7 @@ public struct Subscription: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -630,7 +630,7 @@ public struct Subscription: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionAppStoreReviewScreenshot.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionAppStoreReviewScreenshot.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionAppStoreReviewScreenshot: Codable {
+public struct SubscriptionAppStoreReviewScreenshot: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -91,7 +91,7 @@ public struct SubscriptionAppStoreReviewScreenshot: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionAppStoreReviewScreenshotCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionAppStoreReviewScreenshotCreateRequest.swift
@@ -45,7 +45,7 @@ public struct SubscriptionAppStoreReviewScreenshotCreateRequest: Codable {
 			public struct Subscription: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionAppStoreReviewScreenshotUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionAppStoreReviewScreenshotUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionAppStoreReviewScreenshotUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/SubscriptionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionCreateRequest.swift
@@ -74,7 +74,7 @@ public struct SubscriptionCreateRequest: Codable {
 			public struct Group: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionGracePeriod.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGracePeriod.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionGracePeriod: Codable {
+public struct SubscriptionGracePeriod: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/SubscriptionGracePeriodUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGracePeriodUpdateRequest.swift
@@ -9,7 +9,7 @@ public struct SubscriptionGracePeriodUpdateRequest: Codable {
 	public var data: Data
 	public var included: [AppInlineCreate]?
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -43,7 +43,7 @@ public struct SubscriptionGracePeriodUpdateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionGroup.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGroup.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionGroup: Codable {
+public struct SubscriptionGroup: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -65,7 +65,7 @@ public struct SubscriptionGroup: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -139,7 +139,7 @@ public struct SubscriptionGroup: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionGroupCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGroupCreateRequest.swift
@@ -41,7 +41,7 @@ public struct SubscriptionGroupCreateRequest: Codable {
 			public struct App: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionGroupLocalization.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGroupLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionGroupLocalization: Codable {
+public struct SubscriptionGroupLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -82,7 +82,7 @@ public struct SubscriptionGroupLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionGroupLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGroupLocalizationCreateRequest.swift
@@ -49,7 +49,7 @@ public struct SubscriptionGroupLocalizationCreateRequest: Codable {
 			public struct SubscriptionGroup: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionGroupLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGroupLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionGroupLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/SubscriptionGroupSubmission.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGroupSubmission.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionGroupSubmission: Codable {
+public struct SubscriptionGroupSubmission: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var links: ResourceLinks

--- a/Sources/OpenAPI/Entities/SubscriptionGroupSubmissionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGroupSubmissionCreateRequest.swift
@@ -22,7 +22,7 @@ public struct SubscriptionGroupSubmissionCreateRequest: Codable {
 			public struct SubscriptionGroup: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionGroupUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionGroupUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionGroupUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/SubscriptionIntroductoryOffer.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionIntroductoryOffer.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionIntroductoryOffer: Codable {
+public struct SubscriptionIntroductoryOffer: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -81,7 +81,7 @@ public struct SubscriptionIntroductoryOffer: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -151,7 +151,7 @@ public struct SubscriptionIntroductoryOffer: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -221,7 +221,7 @@ public struct SubscriptionIntroductoryOffer: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionIntroductoryOfferCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionIntroductoryOfferCreateRequest.swift
@@ -60,7 +60,7 @@ public struct SubscriptionIntroductoryOfferCreateRequest: Codable {
 			public struct Subscription: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -104,7 +104,7 @@ public struct SubscriptionIntroductoryOfferCreateRequest: Codable {
 			public struct Territory: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -148,7 +148,7 @@ public struct SubscriptionIntroductoryOfferCreateRequest: Codable {
 			public struct SubscriptionPricePoint: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionIntroductoryOfferInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionIntroductoryOfferInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionIntroductoryOfferInlineCreate: Codable {
+public struct SubscriptionIntroductoryOfferInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var attributes: Attributes
@@ -57,7 +57,7 @@ public struct SubscriptionIntroductoryOfferInlineCreate: Codable {
 		public struct Subscription: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -101,7 +101,7 @@ public struct SubscriptionIntroductoryOfferInlineCreate: Codable {
 		public struct Territory: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -145,7 +145,7 @@ public struct SubscriptionIntroductoryOfferInlineCreate: Codable {
 		public struct SubscriptionPricePoint: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionIntroductoryOfferUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionIntroductoryOfferUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionIntroductoryOfferUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/SubscriptionIntroductoryOffersLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionIntroductoryOffersLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionIntroductoryOffersLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionIntroductoryOffersLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionIntroductoryOffersLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct SubscriptionIntroductoryOffersLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionLocalization.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionLocalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionLocalization: Codable {
+public struct SubscriptionLocalization: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -82,7 +82,7 @@ public struct SubscriptionLocalization: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionLocalizationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionLocalizationCreateRequest.swift
@@ -49,7 +49,7 @@ public struct SubscriptionLocalizationCreateRequest: Codable {
 			public struct Subscription: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionLocalizationUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionLocalizationUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionLocalizationUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCode.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionOfferCode: Codable {
+public struct SubscriptionOfferCode: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -94,7 +94,7 @@ public struct SubscriptionOfferCode: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -165,7 +165,7 @@ public struct SubscriptionOfferCode: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -239,7 +239,7 @@ public struct SubscriptionOfferCode: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -313,7 +313,7 @@ public struct SubscriptionOfferCode: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodeCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodeCreateRequest.swift
@@ -63,7 +63,7 @@ public struct SubscriptionOfferCodeCreateRequest: Codable {
 			public struct Subscription: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -107,7 +107,7 @@ public struct SubscriptionOfferCodeCreateRequest: Codable {
 			public struct Prices: Codable {
 				public var data: [Datum]
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodeCustomCode.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodeCustomCode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionOfferCodeCustomCode: Codable {
+public struct SubscriptionOfferCodeCustomCode: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -79,7 +79,7 @@ public struct SubscriptionOfferCodeCustomCode: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodeCustomCodeCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodeCustomCodeCreateRequest.swift
@@ -49,7 +49,7 @@ public struct SubscriptionOfferCodeCustomCodeCreateRequest: Codable {
 			public struct OfferCode: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodeCustomCodeUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodeCustomCodeUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionOfferCodeCustomCodeUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodeOneTimeUseCode.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodeOneTimeUseCode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionOfferCodeOneTimeUseCode: Codable {
+public struct SubscriptionOfferCodeOneTimeUseCode: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -75,7 +75,7 @@ public struct SubscriptionOfferCodeOneTimeUseCode: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodeOneTimeUseCodeCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodeOneTimeUseCodeCreateRequest.swift
@@ -45,7 +45,7 @@ public struct SubscriptionOfferCodeOneTimeUseCodeCreateRequest: Codable {
 			public struct OfferCode: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodeOneTimeUseCodeUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodeOneTimeUseCodeUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionOfferCodeOneTimeUseCodeUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodeOneTimeUseCodeValue.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodeOneTimeUseCodeValue.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionOfferCodeOneTimeUseCodeValue: Codable {
+public struct SubscriptionOfferCodeOneTimeUseCodeValue: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var links: ResourceLinks

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodePrice.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodePrice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionOfferCodePrice: Codable {
+public struct SubscriptionOfferCodePrice: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var relationships: Relationships?
@@ -45,7 +45,7 @@ public struct SubscriptionOfferCodePrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -115,7 +115,7 @@ public struct SubscriptionOfferCodePrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodePriceInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodePriceInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionOfferCodePriceInlineCreate: Codable {
+public struct SubscriptionOfferCodePriceInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var relationships: Relationships?
@@ -21,7 +21,7 @@ public struct SubscriptionOfferCodePriceInlineCreate: Codable {
 		public struct Territory: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -65,7 +65,7 @@ public struct SubscriptionOfferCodePriceInlineCreate: Codable {
 		public struct SubscriptionPricePoint: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionOfferCodeUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionOfferCodeUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionOfferCodeUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/SubscriptionPrice.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPrice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionPrice: Codable {
+public struct SubscriptionPrice: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -68,7 +68,7 @@ public struct SubscriptionPrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -138,7 +138,7 @@ public struct SubscriptionPrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPriceCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPriceCreateRequest.swift
@@ -47,7 +47,7 @@ public struct SubscriptionPriceCreateRequest: Codable {
 			public struct Subscription: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -91,7 +91,7 @@ public struct SubscriptionPriceCreateRequest: Codable {
 			public struct Territory: Codable {
 				public var data: Data?
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -135,7 +135,7 @@ public struct SubscriptionPriceCreateRequest: Codable {
 			public struct SubscriptionPricePoint: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPriceInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPriceInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionPriceInlineCreate: Codable {
+public struct SubscriptionPriceInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var attributes: Attributes?
@@ -45,7 +45,7 @@ public struct SubscriptionPriceInlineCreate: Codable {
 		public struct Subscription: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -89,7 +89,7 @@ public struct SubscriptionPriceInlineCreate: Codable {
 		public struct Territory: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -133,7 +133,7 @@ public struct SubscriptionPriceInlineCreate: Codable {
 		public struct SubscriptionPricePoint: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPricePoint.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPricePoint.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionPricePoint: Codable {
+public struct SubscriptionPricePoint: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -71,7 +71,7 @@ public struct SubscriptionPricePoint: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPricePointInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPricePointInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionPricePointInlineCreate: Codable {
+public struct SubscriptionPricePointInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 

--- a/Sources/OpenAPI/Entities/SubscriptionPricesLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPricesLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct SubscriptionPricesLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPricesLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPricesLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct SubscriptionPricesLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPromotionalOffer.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPromotionalOffer.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionPromotionalOffer: Codable {
+public struct SubscriptionPromotionalOffer: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -80,7 +80,7 @@ public struct SubscriptionPromotionalOffer: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -151,7 +151,7 @@ public struct SubscriptionPromotionalOffer: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferCreateRequest.swift
@@ -59,7 +59,7 @@ public struct SubscriptionPromotionalOfferCreateRequest: Codable {
 			public struct Subscription: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -103,7 +103,7 @@ public struct SubscriptionPromotionalOfferCreateRequest: Codable {
 			public struct Prices: Codable {
 				public var data: [Datum]
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionPromotionalOfferInlineCreate: Codable {
+public struct SubscriptionPromotionalOfferInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var attributes: Attributes
@@ -56,7 +56,7 @@ public struct SubscriptionPromotionalOfferInlineCreate: Codable {
 		public struct Subscription: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -100,7 +100,7 @@ public struct SubscriptionPromotionalOfferInlineCreate: Codable {
 		public struct Prices: Codable {
 			public var data: [Datum]?
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferPrice.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferPrice.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionPromotionalOfferPrice: Codable {
+public struct SubscriptionPromotionalOfferPrice: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var relationships: Relationships?
@@ -45,7 +45,7 @@ public struct SubscriptionPromotionalOfferPrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -115,7 +115,7 @@ public struct SubscriptionPromotionalOfferPrice: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferPriceInlineCreate.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferPriceInlineCreate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionPromotionalOfferPriceInlineCreate: Codable {
+public struct SubscriptionPromotionalOfferPriceInlineCreate: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String?
 	public var relationships: Relationships?
@@ -21,7 +21,7 @@ public struct SubscriptionPromotionalOfferPriceInlineCreate: Codable {
 		public struct Territory: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 
@@ -65,7 +65,7 @@ public struct SubscriptionPromotionalOfferPriceInlineCreate: Codable {
 		public struct SubscriptionPricePoint: Codable {
 			public var data: Data?
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionPromotionalOfferUpdateRequest.swift
@@ -9,7 +9,7 @@ public struct SubscriptionPromotionalOfferUpdateRequest: Codable {
 	public var data: Data
 	public var included: [SubscriptionPromotionalOfferPriceInlineCreate]?
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var relationships: Relationships?
@@ -24,7 +24,7 @@ public struct SubscriptionPromotionalOfferUpdateRequest: Codable {
 			public struct Prices: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionSubmission.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionSubmission.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SubscriptionSubmission: Codable {
+public struct SubscriptionSubmission: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var relationships: Relationships?
@@ -44,7 +44,7 @@ public struct SubscriptionSubmission: Codable {
 				}
 			}
 
-			public struct Data: Codable {
+			public struct Data: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionSubmissionCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionSubmissionCreateRequest.swift
@@ -22,7 +22,7 @@ public struct SubscriptionSubmissionCreateRequest: Codable {
 			public struct Subscription: Codable {
 				public var data: Data
 
-				public struct Data: Codable {
+				public struct Data: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/SubscriptionUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/SubscriptionUpdateRequest.swift
@@ -9,7 +9,7 @@ public struct SubscriptionUpdateRequest: Codable {
 	public var data: Data
 	public var included: [IncludedItem]?
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -74,7 +74,7 @@ public struct SubscriptionUpdateRequest: Codable {
 			public struct IntroductoryOffers: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -118,7 +118,7 @@ public struct SubscriptionUpdateRequest: Codable {
 			public struct PromotionalOffers: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 
@@ -162,7 +162,7 @@ public struct SubscriptionUpdateRequest: Codable {
 			public struct Prices: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/Territory.swift
+++ b/Sources/OpenAPI/Entities/Territory.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct Territory: Codable {
+public struct Territory: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?

--- a/Sources/OpenAPI/Entities/User.swift
+++ b/Sources/OpenAPI/Entities/User.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct User: Codable {
+public struct User: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -84,7 +84,7 @@ public struct User: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/UserInvitation.swift
+++ b/Sources/OpenAPI/Entities/UserInvitation.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct UserInvitation: Codable {
+public struct UserInvitation: Codable, Identifiable {
 	public var type: `Type`
 	public var id: String
 	public var attributes: Attributes?
@@ -88,7 +88,7 @@ public struct UserInvitation: Codable {
 				}
 			}
 
-			public struct Datum: Codable {
+			public struct Datum: Codable, Identifiable {
 				public var type: `Type`
 				public var id: String
 

--- a/Sources/OpenAPI/Entities/UserInvitationCreateRequest.swift
+++ b/Sources/OpenAPI/Entities/UserInvitationCreateRequest.swift
@@ -61,7 +61,7 @@ public struct UserInvitationCreateRequest: Codable {
 			public struct VisibleApps: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/UserUpdateRequest.swift
+++ b/Sources/OpenAPI/Entities/UserUpdateRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct UserUpdateRequest: Codable {
 	public var data: Data
 
-	public struct Data: Codable {
+	public struct Data: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 		public var attributes: Attributes?
@@ -50,7 +50,7 @@ public struct UserUpdateRequest: Codable {
 			public struct VisibleApps: Codable {
 				public var data: [Datum]?
 
-				public struct Datum: Codable {
+				public struct Datum: Codable, Identifiable {
 					public var type: `Type`
 					public var id: String
 

--- a/Sources/OpenAPI/Entities/UserVisibleAppsLinkagesRequest.swift
+++ b/Sources/OpenAPI/Entities/UserVisibleAppsLinkagesRequest.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct UserVisibleAppsLinkagesRequest: Codable {
 	public var data: [Datum]
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 

--- a/Sources/OpenAPI/Entities/UserVisibleAppsLinkagesResponse.swift
+++ b/Sources/OpenAPI/Entities/UserVisibleAppsLinkagesResponse.swift
@@ -10,7 +10,7 @@ public struct UserVisibleAppsLinkagesResponse: Codable {
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public struct Datum: Codable {
+	public struct Datum: Codable, Identifiable {
 		public var type: `Type`
 		public var id: String
 


### PR DESCRIPTION
New in [CreateAPI 0.0.5](https://github.com/CreateAPI/CreateAPI/releases/tag/0.0.5) is the `isGeneratingIdentifiableConformance` option (`false` by default). 

I spotted that the example used a `List` but had to manually specify the `\.id` key path. This can be avoided if we start generating entities with `Identifiable` conformance out of the box. 

In this PR, I enable the flag, regenerate the entities and update the example. What do you think? 