### PR TITLE
Added paged documents links handling to APIProvider

### DIFF
--- a/Sources/PagedRequest.swift
+++ b/Sources/PagedRequest.swift
@@ -1,0 +1,43 @@
+//
+//  PagedRequest.swift
+//  
+//
+//  Created by Andy Johnson on 05/08/2022.
+//
+
+import Foundation
+
+/// An AsyncSequence of responses to requests from an API endpoint
+///
+/// If the endpoint generates more than a single page of responses the sequence will emit each response page in turn until all have been received.
+public struct PagedRequest<T>: AsyncSequence, AsyncIteratorProtocol where T: Decodable {
+    public typealias Element = T
+    
+    let request: Request<T>
+    let provider: APIProvider
+    
+    init(request: Request<T>, provider: APIProvider) {
+        self.request = request
+        self.provider = provider
+    }
+    
+    private var currentElement: T!
+    
+    public mutating func next() async throws -> T? {
+        guard !Task.isCancelled else {
+            return nil
+        }
+                    
+        if let current = currentElement {
+            currentElement = try await provider.request(request, pageAfter: current)
+        } else {
+            currentElement = try await provider.request(request)
+        }
+        
+        return currentElement
+    }
+    
+    public func makeAsyncIterator() -> Self {
+        self
+    }
+}


### PR DESCRIPTION
Here's a new API for handling paged sets of results from AppStore Connect.

The additions do not rely on chopping up bits of URL to find specific URL Query parameters, rather they access the entire URL passed to the client as the next page link by AppStore Connect, adding in the necessary JWT authentication headers and decoding the subsequent response in the same way a direct call to  APIProvider.request(_) would  decode the response from the endpoint. As such, these functions do not need to care what the endpoint is to use its generic specialisation to apply the correct decode() and return the correct structure.


```swift
    let request = APIEndpoint.v1.apps
        .get(parameters: .init(
            sort: [.bundleID],
            fieldsApps: [.appInfos, .name, .bundleID],
            limit: 2
        ))
    
    // Demonstration of AsyncSequence result of APIProvider.paged(_)
    var allApps: [App] = []
    for try await pagedResult in provider.paged(request) {
        allApps.append(contentsOf: pagedResult.data)
    }

    // Demonstration of APIProvider.hasPagedDocumentLinks(_) and APIProvider.request(_: pageAfter:)
    let firstPageResult = try await provider.request(request)
    let firstPageApps = firstPageResult.data
    print(firstPageApps)
    if provider.hasPagedDocumentLinks(firstPageResult) {        
        if let nextPage = try await provider.request(request, pageAfter: firstPageResult) {
            let secondPageApps = nextPage.data
            print(secondPageApps)
        }
    }

```

APIProvider has new public functions:

    // Does this object have a property that is a PagedDocumentLinks structure?
    public func hasPagedDocumentLinks<T>(_ object: T) -> Bool 

    // If the argument pageAfter has a PagedDocumentLinks.next property, get the next page of results, 
    // decoding the response as if it had been a direct call to the requested endpoint (async version)
    public func request<T>(_ endpoint: Request<T>, pageAfter: T) async throws -> T? 

    // If the argument pageAfter has a PagedDocumentLinks.next property, get the next page of results, 
    // decoding the response as if it had been a direct call to the requested endpoint (completion 
    // handler version)
    public func request<T: Decodable>(_ request: Request<T>, pageAfter currentPage: T, completion: @escaping RequestCompletionHandler<T?>) 

    // Return all pages of responses to the endpoint as an AsyncSequence
    public func paged<T>(_ endpoint: Request<T>) -> PagedRequest<T>  

Fixes #187
