### PR TITLE
Add "UNIVERSAL" case to BundleIDPlatform enum

### DIFF
--- a/Sources/OpenAPI/Entities/BundleIDPlatform.swift
+++ b/Sources/OpenAPI/Entities/BundleIDPlatform.swift
@@ -8,4 +8,5 @@ import Foundation
 public enum BundleIDPlatform: String, Codable, CaseIterable {
 	case ios = "IOS"
 	case macOs = "MAC_OS"
+	case universal = "UNIVERSAL"
 }


### PR DESCRIPTION
In the [ASC docs for BundleIDPlatform](https://developer.apple.com/documentation/appstoreconnectapi/bundleidplatform) and in the code generated from `app_store_connect_api_2.0_openapi.json` spec, [`BundleIdPlatform`](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/master/Sources/OpenAPI/Entities/BundleIDPlatform.swift) is an enum that can be "IOS" or "MAC_OS". However, the ASC servers break this by sometimes returning "UNIVERSAL".

This was noticed and corrected in 2020 in https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/70, but it appears that the additional case that was manually added was then eventually lost in a refactoring.

The discrepancy between the spec and the data returned the servers is out of our control, and this highlights an underlying brittleness to using frozen enums to represent enumerations that may get additional cases added to them in the future. Any enum that starts returning an unhandled case will break the entire parse, making forward-compatible clients impossible.

I think the long-term solution to this issue would be to have an option of generating an enum-simulating `RawRepresentable` wrapper around the string with some convenience public static accessors initializer. For example, something like: 

```swift
struct BundleIdPlatform : RawRepresentable, Coddle { 
    var rawValue: String
    static let ios = Self(rawValue: "IOS")
    static let macos = Self(rawValue: "MAC_OS")
}

extension BundleIdPlatform {
    // unhandled cases can be manually added with an extension
    static let universal = Self(rawValue: "UNIVERSAL")
}
```

Support for this would be need to be implemented in https://github.com/CreateAPI/CreateAPI, since their enum handling code seems hardwired (and unaffected by my setting `generateEnums: false` in `.create-api.yml`, as well as adding the "UNIVERSAL" case to the `rename.enumCases` property).

This short term patch simply manually adds in the undocumented "UNIVERSAL" case, but since this will need to be done every time the API is re-generated, it is not a great solution. 

For the record, here is an example of the parse failure when the server returns the unhandled case:

```
<unknown>:0: error: -[FairExpoTests.AppConnectTests testAppConnect] : failed: caught error: "Failed to decode response:
{
  "data" : {
    "type" : "bundleIds",
    "id" : "…",
    "attributes" : {
      "name" : "…",
      "identifier" : "…",
      "platform" : "UNIVERSAL",
      "seedId" : "…"
    },
    "relationships" : {
      "bundleIdCapabilities" : {
        "meta" : {
          "paging" : {
            "total" : 0,
            "limit" : 2147483647
          }
        },
        "data" : [ {
          "type" : "bundleIdCapabilities",
          "id" : "…_IN_APP_PURCHASE"
        } ],
        "links" : {
          "self" : "https://api.appstoreconnect.apple.com/v1/bundleIds/…/relationships/bundleIdCapabilities",
          "related" : "https://api.appstoreconnect.apple.com/v1/bundleIds/…/bundleIdCapabilities"
        }
      },
      "profiles" : {
        "meta" : {
          "paging" : {
            "total" : 0,
            "limit" : 2147483647
          }
        },
        "data" : [ ],
        "links" : {
          "self" : "https://api.appstoreconnect.apple.com/v1/bundleIds/…/relationships/profiles",
          "related" : "https://api.appstoreconnect.apple.com/v1/bundleIds/…/profiles"
        }
      }
    },
    "links" : {
      "self" : "https://api.appstoreconnect.apple.com/v1/bundleIds/…"
    }
  },
  "links" : {
    "self" : "https://api.appstoreconnect.apple.com/v1/bundleIds"
  }
}
Error: dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "data", intValue: nil), CodingKeys(stringValue: "attributes", intValue: nil), CodingKeys(stringValue: "platform", intValue: nil)], debugDescription: "Cannot initialize BundleIDPlatform from invalid String value UNIVERSAL", underlyingError: nil))."
```

