### PR TITLE
Regenerated code for App Store Connect API 2.1 changes

### DIFF
--- a/.github/workflows/sync_asc_api.yml
+++ b/.github/workflows/sync_asc_api.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       # Grab the latest spec and perform some manual coersion to fix errors.
       # (see https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/197)
-      - run: curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL" ] | del(.["x-important"])' > Sources/OpenAPI/app_store_connect_api_2.0_openapi.json
+      - run: curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL" ] | del(.["x-important"]) | del(.. |."enum"? | select(. != null and length == 0))' > Sources/OpenAPI/app_store_connect_api_2.0_openapi.json
 
       # If there are any differences, this step will fail
       # and issue a notification. The api will then need to be

--- a/Sources/OpenAPI/Generated/Entities/BundleIDPlatform.swift
+++ b/Sources/OpenAPI/Generated/Entities/BundleIDPlatform.swift
@@ -8,4 +8,5 @@ import Foundation
 public enum BundleIDPlatform: String, Codable, CaseIterable {
 	case ios = "IOS"
 	case macOs = "MAC_OS"
+	case universal = "UNIVERSAL"
 }

--- a/Sources/OpenAPI/Generated/Entities/PreviewType.swift
+++ b/Sources/OpenAPI/Generated/Entities/PreviewType.swift
@@ -6,6 +6,8 @@
 import Foundation
 
 public enum PreviewType: String, Codable, CaseIterable {
+	case iphone67 = "IPHONE_67"
+	case iphone61 = "IPHONE_61"
 	case iphone65 = "IPHONE_65"
 	case iphone58 = "IPHONE_58"
 	case iphone55 = "IPHONE_55"
@@ -18,7 +20,5 @@ public enum PreviewType: String, Codable, CaseIterable {
 	case ipad105 = "IPAD_105"
 	case ipad97 = "IPAD_97"
 	case desktop = "DESKTOP"
-	case watchSeries4 = "WATCH_SERIES_4"
-	case watchSeries3 = "WATCH_SERIES_3"
 	case appleTv = "APPLE_TV"
 }

--- a/Sources/OpenAPI/Generated/Entities/ScreenshotDisplayType.swift
+++ b/Sources/OpenAPI/Generated/Entities/ScreenshotDisplayType.swift
@@ -6,6 +6,8 @@
 import Foundation
 
 public enum ScreenshotDisplayType: String, Codable, CaseIterable {
+	case appIphone67 = "APP_IPHONE_67"
+	case appIphone61 = "APP_IPHONE_61"
 	case appIphone65 = "APP_IPHONE_65"
 	case appIphone58 = "APP_IPHONE_58"
 	case appIphone55 = "APP_IPHONE_55"
@@ -18,10 +20,13 @@ public enum ScreenshotDisplayType: String, Codable, CaseIterable {
 	case appIpad105 = "APP_IPAD_105"
 	case appIpad97 = "APP_IPAD_97"
 	case appDesktop = "APP_DESKTOP"
+	case appWatchUltra = "APP_WATCH_ULTRA"
 	case appWatchSeries7 = "APP_WATCH_SERIES_7"
 	case appWatchSeries4 = "APP_WATCH_SERIES_4"
 	case appWatchSeries3 = "APP_WATCH_SERIES_3"
 	case appAppleTv = "APP_APPLE_TV"
+	case imessageAppIphone67 = "IMESSAGE_APP_IPHONE_67"
+	case imessageAppIphone61 = "IMESSAGE_APP_IPHONE_61"
 	case imessageAppIphone65 = "IMESSAGE_APP_IPHONE_65"
 	case imessageAppIphone58 = "IMESSAGE_APP_IPHONE_58"
 	case imessageAppIphone55 = "IMESSAGE_APP_IPHONE_55"

--- a/Sources/OpenAPI/Generated/Paths/PathsV1AppCustomProductPageLocalizationsWithIDAppPreviewSets.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1AppCustomProductPageLocalizationsWithIDAppPreviewSets.swift
@@ -33,6 +33,8 @@ extension APIEndpoint.V1.AppCustomProductPageLocalizations.WithID {
 			public var include: [Include]?
 
 			public enum FilterPreviewType: String, Codable, CaseIterable {
+				case iphone67 = "IPHONE_67"
+				case iphone61 = "IPHONE_61"
 				case iphone65 = "IPHONE_65"
 				case iphone58 = "IPHONE_58"
 				case iphone55 = "IPHONE_55"
@@ -45,8 +47,6 @@ extension APIEndpoint.V1.AppCustomProductPageLocalizations.WithID {
 				case ipad105 = "IPAD_105"
 				case ipad97 = "IPAD_97"
 				case desktop = "DESKTOP"
-				case watchSeries4 = "WATCH_SERIES_4"
-				case watchSeries3 = "WATCH_SERIES_3"
 				case appleTv = "APPLE_TV"
 			}
 

--- a/Sources/OpenAPI/Generated/Paths/PathsV1AppCustomProductPageLocalizationsWithIDAppScreenshotSets.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1AppCustomProductPageLocalizationsWithIDAppScreenshotSets.swift
@@ -33,6 +33,8 @@ extension APIEndpoint.V1.AppCustomProductPageLocalizations.WithID {
 			public var include: [Include]?
 
 			public enum FilterScreenshotDisplayType: String, Codable, CaseIterable {
+				case appIphone67 = "APP_IPHONE_67"
+				case appIphone61 = "APP_IPHONE_61"
 				case appIphone65 = "APP_IPHONE_65"
 				case appIphone58 = "APP_IPHONE_58"
 				case appIphone55 = "APP_IPHONE_55"
@@ -45,10 +47,13 @@ extension APIEndpoint.V1.AppCustomProductPageLocalizations.WithID {
 				case appIpad105 = "APP_IPAD_105"
 				case appIpad97 = "APP_IPAD_97"
 				case appDesktop = "APP_DESKTOP"
+				case appWatchUltra = "APP_WATCH_ULTRA"
 				case appWatchSeries7 = "APP_WATCH_SERIES_7"
 				case appWatchSeries4 = "APP_WATCH_SERIES_4"
 				case appWatchSeries3 = "APP_WATCH_SERIES_3"
 				case appAppleTv = "APP_APPLE_TV"
+				case imessageAppIphone67 = "IMESSAGE_APP_IPHONE_67"
+				case imessageAppIphone61 = "IMESSAGE_APP_IPHONE_61"
 				case imessageAppIphone65 = "IMESSAGE_APP_IPHONE_65"
 				case imessageAppIphone58 = "IMESSAGE_APP_IPHONE_58"
 				case imessageAppIphone55 = "IMESSAGE_APP_IPHONE_55"

--- a/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionExperimentTreatmentLocalizationsWithIDAppPreviewSets.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionExperimentTreatmentLocalizationsWithIDAppPreviewSets.swift
@@ -33,6 +33,8 @@ extension APIEndpoint.V1.AppStoreVersionExperimentTreatmentLocalizations.WithID 
 			public var include: [Include]?
 
 			public enum FilterPreviewType: String, Codable, CaseIterable {
+				case iphone67 = "IPHONE_67"
+				case iphone61 = "IPHONE_61"
 				case iphone65 = "IPHONE_65"
 				case iphone58 = "IPHONE_58"
 				case iphone55 = "IPHONE_55"
@@ -45,8 +47,6 @@ extension APIEndpoint.V1.AppStoreVersionExperimentTreatmentLocalizations.WithID 
 				case ipad105 = "IPAD_105"
 				case ipad97 = "IPAD_97"
 				case desktop = "DESKTOP"
-				case watchSeries4 = "WATCH_SERIES_4"
-				case watchSeries3 = "WATCH_SERIES_3"
 				case appleTv = "APPLE_TV"
 			}
 

--- a/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionExperimentTreatmentLocalizationsWithIDAppScreenshotSets.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionExperimentTreatmentLocalizationsWithIDAppScreenshotSets.swift
@@ -33,6 +33,8 @@ extension APIEndpoint.V1.AppStoreVersionExperimentTreatmentLocalizations.WithID 
 			public var include: [Include]?
 
 			public enum FilterScreenshotDisplayType: String, Codable, CaseIterable {
+				case appIphone67 = "APP_IPHONE_67"
+				case appIphone61 = "APP_IPHONE_61"
 				case appIphone65 = "APP_IPHONE_65"
 				case appIphone58 = "APP_IPHONE_58"
 				case appIphone55 = "APP_IPHONE_55"
@@ -45,10 +47,13 @@ extension APIEndpoint.V1.AppStoreVersionExperimentTreatmentLocalizations.WithID 
 				case appIpad105 = "APP_IPAD_105"
 				case appIpad97 = "APP_IPAD_97"
 				case appDesktop = "APP_DESKTOP"
+				case appWatchUltra = "APP_WATCH_ULTRA"
 				case appWatchSeries7 = "APP_WATCH_SERIES_7"
 				case appWatchSeries4 = "APP_WATCH_SERIES_4"
 				case appWatchSeries3 = "APP_WATCH_SERIES_3"
 				case appAppleTv = "APP_APPLE_TV"
+				case imessageAppIphone67 = "IMESSAGE_APP_IPHONE_67"
+				case imessageAppIphone61 = "IMESSAGE_APP_IPHONE_61"
 				case imessageAppIphone65 = "IMESSAGE_APP_IPHONE_65"
 				case imessageAppIphone58 = "IMESSAGE_APP_IPHONE_58"
 				case imessageAppIphone55 = "IMESSAGE_APP_IPHONE_55"

--- a/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionLocalizationsWithIDAppPreviewSets.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionLocalizationsWithIDAppPreviewSets.swift
@@ -33,6 +33,8 @@ extension APIEndpoint.V1.AppStoreVersionLocalizations.WithID {
 			public var include: [Include]?
 
 			public enum FilterPreviewType: String, Codable, CaseIterable {
+				case iphone67 = "IPHONE_67"
+				case iphone61 = "IPHONE_61"
 				case iphone65 = "IPHONE_65"
 				case iphone58 = "IPHONE_58"
 				case iphone55 = "IPHONE_55"
@@ -45,8 +47,6 @@ extension APIEndpoint.V1.AppStoreVersionLocalizations.WithID {
 				case ipad105 = "IPAD_105"
 				case ipad97 = "IPAD_97"
 				case desktop = "DESKTOP"
-				case watchSeries4 = "WATCH_SERIES_4"
-				case watchSeries3 = "WATCH_SERIES_3"
 				case appleTv = "APPLE_TV"
 			}
 

--- a/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionLocalizationsWithIDAppScreenshotSets.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1AppStoreVersionLocalizationsWithIDAppScreenshotSets.swift
@@ -33,6 +33,8 @@ extension APIEndpoint.V1.AppStoreVersionLocalizations.WithID {
 			public var include: [Include]?
 
 			public enum FilterScreenshotDisplayType: String, Codable, CaseIterable {
+				case appIphone67 = "APP_IPHONE_67"
+				case appIphone61 = "APP_IPHONE_61"
 				case appIphone65 = "APP_IPHONE_65"
 				case appIphone58 = "APP_IPHONE_58"
 				case appIphone55 = "APP_IPHONE_55"
@@ -45,10 +47,13 @@ extension APIEndpoint.V1.AppStoreVersionLocalizations.WithID {
 				case appIpad105 = "APP_IPAD_105"
 				case appIpad97 = "APP_IPAD_97"
 				case appDesktop = "APP_DESKTOP"
+				case appWatchUltra = "APP_WATCH_ULTRA"
 				case appWatchSeries7 = "APP_WATCH_SERIES_7"
 				case appWatchSeries4 = "APP_WATCH_SERIES_4"
 				case appWatchSeries3 = "APP_WATCH_SERIES_3"
 				case appAppleTv = "APP_APPLE_TV"
+				case imessageAppIphone67 = "IMESSAGE_APP_IPHONE_67"
+				case imessageAppIphone61 = "IMESSAGE_APP_IPHONE_61"
 				case imessageAppIphone65 = "IMESSAGE_APP_IPHONE_65"
 				case imessageAppIphone58 = "IMESSAGE_APP_IPHONE_58"
 				case imessageAppIphone55 = "IMESSAGE_APP_IPHONE_55"

--- a/Sources/OpenAPI/Generated/Paths/PathsV1SubscriptionOfferCodeOneTimeUseCodesWithID.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1SubscriptionOfferCodeOneTimeUseCodesWithID.swift
@@ -22,7 +22,7 @@ extension APIEndpoint.V1.SubscriptionOfferCodeOneTimeUseCodes {
 		public struct GetParameters {
 			public var fieldsSubscriptionOfferCodeOneTimeUseCodes: [FieldsSubscriptionOfferCodeOneTimeUseCodes]?
 			public var include: [Include]?
-			public var fieldsSubscriptionOfferCodeOneTimeUseCodeValues: [FieldsSubscriptionOfferCodeOneTimeUseCodeValues]?
+			public var fieldsSubscriptionOfferCodeOneTimeUseCodeValues: [String]?
 
 			public enum FieldsSubscriptionOfferCodeOneTimeUseCodes: String, Codable, CaseIterable {
 				case active
@@ -37,11 +37,7 @@ extension APIEndpoint.V1.SubscriptionOfferCodeOneTimeUseCodes {
 				case offerCode
 			}
 
-			public enum FieldsSubscriptionOfferCodeOneTimeUseCodeValues: String, Codable, CaseIterable {
-				case empty
-			}
-
-			public init(fieldsSubscriptionOfferCodeOneTimeUseCodes: [FieldsSubscriptionOfferCodeOneTimeUseCodes]? = nil, include: [Include]? = nil, fieldsSubscriptionOfferCodeOneTimeUseCodeValues: [FieldsSubscriptionOfferCodeOneTimeUseCodeValues]? = nil) {
+			public init(fieldsSubscriptionOfferCodeOneTimeUseCodes: [FieldsSubscriptionOfferCodeOneTimeUseCodes]? = nil, include: [Include]? = nil, fieldsSubscriptionOfferCodeOneTimeUseCodeValues: [String]? = nil) {
 				self.fieldsSubscriptionOfferCodeOneTimeUseCodes = fieldsSubscriptionOfferCodeOneTimeUseCodes
 				self.include = include
 				self.fieldsSubscriptionOfferCodeOneTimeUseCodeValues = fieldsSubscriptionOfferCodeOneTimeUseCodeValues

--- a/Sources/OpenAPI/app_store_connect_api_2.0_openapi.json
+++ b/Sources/OpenAPI/app_store_connect_api_2.0_openapi.json
@@ -1,6 +1,5 @@
 {
   "openapi": "3.0.1",
-  "x-important": "IMPORTANT:  This OpenAPI Specification is only for use in accordance with the terms of the Apple Developer Program License Agreement and terms for the use of the App Store Connect API.  You may not use this OpenAPI Specification unless you have agreed to the Apple Developer Program License Agreement, and You acknowledge and agree that the App Store Connect API (and use of this Specification in connection therewith) is for internal development, testing and reporting purposes within your team and not to provide services to any third parties or for any other use.",
   "info": {
     "title": "App Store Connect API",
     "version": "2.1",
@@ -29680,8 +29679,7 @@
             "schema": {
               "type": "array",
               "items": {
-                "type": "string",
-                "enum": []
+                "type": "string"
               }
             },
             "style": "form",


### PR DESCRIPTION
A continuation of https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/207.

It looks like the generated code itself wasn't updated in #207 because the script used didn't remove that empty enum. CreateAPI doesn't do a great job of exposing the error that occurred so it went unnoticed. 

This change fixes the script by removing any empty enums from the schema when importing. 

I generated this diff by doing the following:

```bash
$ curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL" ] | del(.["x-important"]) | del(.. |."enum"? | select(. != null and length == 0))' > Sources/OpenAPI/app_store_connect_api_2.0_openapi.json
$ swift package --allow-writing-to-package-directory generate-open-api
```


@AvdLee: it might be beneficial to expose a convenient way to run the above locally rather than just in that CI script? WDYT if I add a **Makefile** with some commands... For example we could have `make update` that does the above. We could then also use it in the CI script? 