### PR TITLE
Fix diagnostic log return types

### DIFF
--- a/Sources/OpenAPI/.create-api.yml
+++ b/Sources/OpenAPI/.create-api.yml
@@ -26,6 +26,12 @@ paths:
   # Tries to remove redundant paths
   isRemovingRedundantPaths: true
   namespace: "APIEndpoint"
+  # Adds known types to Apple specific content-types.
+  # In CreateAPI 0.5.0 there is a typo, update this configuration key when moving to newer version
+  # (https://github.com/CreateAPI/CreateAPI/pull/78).
+  overridenBodyTypes:
+    application/vnd.apple.diagnostic-logs+json: DiagnosticLogs
+    application/vnd.apple.xcode-metrics+json: XcodeMetrics
 
 entities:
   isGeneratingCustomCodingKeys: false

--- a/Sources/OpenAPI/Generated/Paths/PathsV1AppsWithIDPerfPowerMetrics.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1AppsWithIDPerfPowerMetrics.swift
@@ -15,7 +15,7 @@ extension APIEndpoint.V1.Apps.WithID {
 		/// Path: `/v1/apps/{id}/perfPowerMetrics`
 		public let path: String
 
-		public func get(parameters: GetParameters? = nil) -> Request<Data> {
+		public func get(parameters: GetParameters? = nil) -> Request<XcodeMetrics> {
 			.get(path, query: parameters?.asQuery)
 		}
 

--- a/Sources/OpenAPI/Generated/Paths/PathsV1BuildsWithIDPerfPowerMetrics.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1BuildsWithIDPerfPowerMetrics.swift
@@ -15,7 +15,7 @@ extension APIEndpoint.V1.Builds.WithID {
 		/// Path: `/v1/builds/{id}/perfPowerMetrics`
 		public let path: String
 
-		public func get(parameters: GetParameters? = nil) -> Request<Data> {
+		public func get(parameters: GetParameters? = nil) -> Request<XcodeMetrics> {
 			.get(path, query: parameters?.asQuery)
 		}
 

--- a/Sources/OpenAPI/Generated/Paths/PathsV1DiagnosticSignaturesWithIDLogs.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1DiagnosticSignaturesWithIDLogs.swift
@@ -15,7 +15,7 @@ extension APIEndpoint.V1.DiagnosticSignatures.WithID {
 		/// Path: `/v1/diagnosticSignatures/{id}/logs`
 		public let path: String
 
-		public func get(limit: Int? = nil) -> Request<Data> {
+		public func get(limit: Int? = nil) -> Request<DiagnosticLogs> {
 			.get(path, query: makeGetQuery(limit))
 		}
 


### PR DESCRIPTION
Perf power metrics and one diagnostic requests return `Data` instead of `Codable` models. `Codable` models are generated, but the body type schema is not used correctly. This is due to some Apple-specific content-types which are specified in the OpenAPI spec. Hopefully, CreateAPI provides configuration to override such body types.

Also fixes following warnings in the `make generate` step.

```
WARNING: Unknown body content types: [OpenAPIKitCore.OpenAPI.ContentType(underlyingType: OpenAPIKitCore.OpenAPI.ContentType.Builtin.other("application/vnd.apple.xcode-metrics+json"), warnings: [], parameters: [:])], defaulting to Data. Use paths.overridenBodyTypes to add support for your content types.
WARNING: Unknown body content types: [OpenAPIKitCore.OpenAPI.ContentType(underlyingType: OpenAPIKitCore.OpenAPI.ContentType.Builtin.other("application/vnd.apple.xcode-metrics+json"), warnings: [], parameters: [:])], defaulting to Data. Use paths.overridenBodyTypes to add support for your content types.
WARNING: Unknown body content types: [OpenAPIKitCore.OpenAPI.ContentType(underlyingType: OpenAPIKitCore.OpenAPI.ContentType.Builtin.other("application/vnd.apple.diagnostic-logs+json"), warnings: [], parameters: [:])], defaulting to Data. Use paths.overridenBodyTypes to add support for your content types.
```

There is a typo in the `overridenBodyTypes` configuration key in version 0.5.0 of CreateAPI (fixed in 1.0.0). I recommend updating it.