### PR TITLE
Adds rate limit to APIProvider

### DIFF
--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -133,7 +133,7 @@ public final class APIProvider {
     /// The JSON encoder used to encode request parameters.
     private let encoder: JSONEncoder
     
-    /// The rate limit information from the latest API request
+    /// Exposes rate limit continously as requests are made.
     public let rateLimitPublisher = PassthroughSubject<RateLimit, Never>()
 
     /// Creates a new APIProvider instance which can be used to perform API Requests to the App Store Connect API.

--- a/Sources/DefaultRequestExecutor.swift
+++ b/Sources/DefaultRequestExecutor.swift
@@ -64,7 +64,7 @@ func mapResponse(data: Data?, urlResponse: URLResponse?, error: Error?) -> Resul
             return .failure(DefaultRequestExecutor.Error.unknownResponseType)
         }
 
-        return .success(.init(requestURL: httpUrlResponse.url, statusCode: httpUrlResponse.statusCode, allHeaderFields: httpUrlResponse.allHeaderFields, data: data))
+        return .success(.init(requestURL: httpUrlResponse.url, statusCode: httpUrlResponse.statusCode, rateLimit: httpUrlResponse.rateLimit, data: data))
     }
 }
 
@@ -83,6 +83,6 @@ func mapResponse(fileUrl: URL?, urlResponse: URLResponse?, error: Error?) -> Res
             return .failure(DefaultRequestExecutor.Error.unknownResponseType)
         }
 
-        return .success(.init(requestURL: httpUrlResponse.url, statusCode: httpUrlResponse.statusCode, allHeaderFields: httpUrlResponse.allHeaderFields, data: fileUrl))
+        return .success(.init(requestURL: httpUrlResponse.url, statusCode: httpUrlResponse.statusCode, rateLimit: httpUrlResponse.rateLimit, data: fileUrl))
     }
 }

--- a/Sources/DefaultRequestExecutor.swift
+++ b/Sources/DefaultRequestExecutor.swift
@@ -64,7 +64,7 @@ func mapResponse(data: Data?, urlResponse: URLResponse?, error: Error?) -> Resul
             return .failure(DefaultRequestExecutor.Error.unknownResponseType)
         }
 
-        return .success(.init(requestURL: httpUrlResponse.url, statusCode: httpUrlResponse.statusCode, data: data))
+        return .success(.init(requestURL: httpUrlResponse.url, statusCode: httpUrlResponse.statusCode, allHeaderFields: httpUrlResponse.allHeaderFields, data: data))
     }
 }
 
@@ -83,6 +83,6 @@ func mapResponse(fileUrl: URL?, urlResponse: URLResponse?, error: Error?) -> Res
             return .failure(DefaultRequestExecutor.Error.unknownResponseType)
         }
 
-        return .success(.init(requestURL: httpUrlResponse.url, statusCode: httpUrlResponse.statusCode, data: fileUrl))
+        return .success(.init(requestURL: httpUrlResponse.url, statusCode: httpUrlResponse.statusCode, allHeaderFields: httpUrlResponse.allHeaderFields, data: fileUrl))
     }
 }

--- a/Sources/Extensions/HTTPURLResponseExtensions.swift
+++ b/Sources/Extensions/HTTPURLResponseExtensions.swift
@@ -1,0 +1,18 @@
+//
+//  HTTPURLResponseExtensions.swift
+//  
+//
+//  Created by Mathias Emil Mortensen on 10/04/2023.
+//
+
+import Foundation
+
+extension HTTPURLResponse {
+    var rateLimit: RateLimit? {
+        if let value = value(forHTTPHeaderField: "X-Rate-Limit") {
+            return RateLimit(value: value, requestURL: url)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/RateLimit.swift
+++ b/Sources/RateLimit.swift
@@ -14,7 +14,10 @@ public struct RateLimit {
     /// Number of requests remaining. The time frame is a "rolling hour."
     public let remainingInCurrentHour: Int
     
-    init?(value: String) {
+    /// The url of the request the rate limit were returned for.
+    public let requestURL: URL?
+    
+    init?(value: String, requestURL: URL?) {
         let components = value.split(separator: ";", omittingEmptySubsequences: true)
         
         guard
@@ -33,6 +36,7 @@ public struct RateLimit {
         
         hourlyLimit = limit
         remainingInCurrentHour = remaining
+        self.requestURL = requestURL
     }
 }
 

--- a/Sources/RateLimit.swift
+++ b/Sources/RateLimit.swift
@@ -1,0 +1,43 @@
+//
+//  RateLimit.swift
+//  
+//
+//  Created by Mathias Emil Mortensen on 05/04/2023.
+//
+
+import Foundation
+
+public struct RateLimit {
+    /// Number of requests you can make per hour with the same API key.
+    public let hourlyLimit: Int
+    
+    /// Number of requests remaining. The time frame is a "rolling hour."
+    public let remainingInCurrentHour: Int
+    
+    init?(value: String) {
+        let components = value.split(separator: ";", omittingEmptySubsequences: true)
+        
+        guard
+            let limitString = components.value(for: "user-hour-lim:"),
+            let remainingString = components.value(for: "user-hour-rem:")
+        else {
+            return nil
+        }
+        
+        guard
+            let limit = Int(limitString),
+            let remaining = Int(remainingString)
+        else {
+            return nil
+        }
+        
+        hourlyLimit = limit
+        remainingInCurrentHour = remaining
+    }
+}
+
+private extension Sequence where Element == String.SubSequence {
+    func value(for key: String) -> String? {
+        first(where: { $0.contains(key) }).map { $0.replacingOccurrences(of: key, with: "") }
+    }
+}

--- a/Sources/RateLimit.swift
+++ b/Sources/RateLimit.swift
@@ -8,40 +8,26 @@
 import Foundation
 
 public struct RateLimit {
-    /// Number of requests you can make per hour with the same API key.
-    public let hourlyLimit: Int
-    
-    /// Number of requests remaining. The time frame is a "rolling hour."
-    public let remainingInCurrentHour: Int
+    /// Rate limit entries
+    public let entries: [String: Int]
     
     /// The url of the request the rate limit were returned for.
     public let requestURL: URL?
     
-    init?(value: String, requestURL: URL?) {
-        let components = value.split(separator: ";", omittingEmptySubsequences: true)
-        
-        guard
-            let limitString = components.value(for: "user-hour-lim:"),
-            let remainingString = components.value(for: "user-hour-rem:")
-        else {
-            return nil
-        }
-        
-        guard
-            let limit = Int(limitString),
-            let remaining = Int(remainingString)
-        else {
-            return nil
-        }
-        
-        hourlyLimit = limit
-        remainingInCurrentHour = remaining
+    init(value: String, requestURL: URL?) {
         self.requestURL = requestURL
-    }
-}
-
-private extension Sequence where Element == String.SubSequence {
-    func value(for key: String) -> String? {
-        first(where: { $0.contains(key) }).map { $0.replacingOccurrences(of: key, with: "") }
+        
+        let items = value.split(separator: ";", omittingEmptySubsequences: true)
+        entries = items.reduce(into: [:]) { partialResult, item in
+            guard let colonIdx = item.firstIndex(of: ":") else {
+                return
+            }
+            let key = item[..<colonIdx]
+            let valueString = item[item.index(after: colonIdx)...]
+            guard let value = Int(valueString) else {
+                return
+            }
+            partialResult[String(key)] = value
+        }
     }
 }

--- a/Sources/RequestExecutor.swift
+++ b/Sources/RequestExecutor.swift
@@ -32,7 +32,7 @@ public struct Response<T> {
         }
         
         if let rateLimitValue = allHeaderFields["X-Rate-Limit"] as? String {
-            self.rateLimit = RateLimit(value: rateLimitValue)
+            self.rateLimit = RateLimit(value: rateLimitValue, requestURL: requestURL)
         } else {
             self.rateLimit = nil
         }

--- a/Sources/RequestExecutor.swift
+++ b/Sources/RequestExecutor.swift
@@ -20,21 +20,16 @@ public struct Response<T> {
     public let errorResponse: ErrorResponse?
     public let rateLimit: RateLimit?
 
-    public init(requestURL: URL?, statusCode: StatusCode, allHeaderFields: [AnyHashable: Any], data: T?) {
+    public init(requestURL: URL?, statusCode: StatusCode, rateLimit: RateLimit?, data: T?) {
         self.requestURL = requestURL
         self.statusCode = statusCode
+        self.rateLimit = rateLimit
         self.data = data
 
         if let data = data as? Data {
             self.errorResponse = try? APIProvider.jsonDecoder.decode(ErrorResponse.self, from: data)
         } else {
             self.errorResponse = nil
-        }
-        
-        if let rateLimitValue = allHeaderFields["X-Rate-Limit"] as? String {
-            self.rateLimit = RateLimit(value: rateLimitValue, requestURL: requestURL)
-        } else {
-            self.rateLimit = nil
         }
     }
 }

--- a/Sources/RequestExecutor.swift
+++ b/Sources/RequestExecutor.swift
@@ -18,8 +18,9 @@ public struct Response<T> {
     public let statusCode: Int
     public let data: T?
     public let errorResponse: ErrorResponse?
+    public let rateLimit: RateLimit?
 
-    public init(requestURL: URL?, statusCode: StatusCode, data: T?) {
+    public init(requestURL: URL?, statusCode: StatusCode, allHeaderFields: [AnyHashable: Any], data: T?) {
         self.requestURL = requestURL
         self.statusCode = statusCode
         self.data = data
@@ -28,6 +29,12 @@ public struct Response<T> {
             self.errorResponse = try? APIProvider.jsonDecoder.decode(ErrorResponse.self, from: data)
         } else {
             self.errorResponse = nil
+        }
+        
+        if let rateLimitValue = allHeaderFields["X-Rate-Limit"] as? String {
+            self.rateLimit = RateLimit(value: rateLimitValue)
+        } else {
+            self.rateLimit = nil
         }
     }
 }

--- a/Tests/APIProviderTests.swift
+++ b/Tests/APIProviderTests.swift
@@ -51,7 +51,7 @@ final class APIProviderTests: XCTestCase {
     // MARK: - Tests
 
     func testRequestExecutionWithVoidResponse() {
-        let response = Response<Data>(requestURL: nil, statusCode: 200, allHeaderFields: [:], data: nil)
+        let response = Response<Data>(requestURL: nil, statusCode: 200, rateLimit: nil, data: nil)
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)
 
@@ -74,7 +74,7 @@ final class APIProviderTests: XCTestCase {
             )
         ])
         let responseData = try JSONEncoder().encode(errorResponse)
-        let response = Response<Data>(requestURL: expectedURL, statusCode: 404, allHeaderFields: [:], data: responseData)
+        let response = Response<Data>(requestURL: expectedURL, statusCode: 404, rateLimit: nil, data: responseData)
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)
 
@@ -102,7 +102,7 @@ final class APIProviderTests: XCTestCase {
     }
 
     func testDownloadRequestWithResultSuccess() {
-        let response = Response(requestURL: nil, statusCode: 200, allHeaderFields: [:], data: URL(fileURLWithPath: "randompath"))
+        let response = Response(requestURL: nil, statusCode: 200, rateLimit: nil, data: URL(fileURLWithPath: "randompath"))
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
 
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)
@@ -119,7 +119,7 @@ final class APIProviderTests: XCTestCase {
     }
 
     func testDownloadRequestWithProblemOnFileCreation() {
-        let response = Response<URL>(requestURL: nil, statusCode: 200, allHeaderFields: [:], data: nil)
+        let response = Response<URL>(requestURL: nil, statusCode: 200, rateLimit: nil, data: nil)
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
 
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)
@@ -141,7 +141,7 @@ final class APIProviderTests: XCTestCase {
     }
 
     func testDownloadRequestWithFailure() {
-        let response = Response<URL>(requestURL: nil, statusCode: 500, allHeaderFields: [:], data: nil)
+        let response = Response<URL>(requestURL: nil, statusCode: 500, rateLimit: nil, data: nil)
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
 
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)

--- a/Tests/APIProviderTests.swift
+++ b/Tests/APIProviderTests.swift
@@ -51,7 +51,7 @@ final class APIProviderTests: XCTestCase {
     // MARK: - Tests
 
     func testRequestExecutionWithVoidResponse() {
-        let response = Response<Data>(requestURL: nil, statusCode: 200, data: nil)
+        let response = Response<Data>(requestURL: nil, statusCode: 200, allHeaderFields: [:], data: nil)
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)
 
@@ -74,7 +74,7 @@ final class APIProviderTests: XCTestCase {
             )
         ])
         let responseData = try JSONEncoder().encode(errorResponse)
-        let response = Response<Data>(requestURL: expectedURL, statusCode: 404, data: responseData)
+        let response = Response<Data>(requestURL: expectedURL, statusCode: 404, allHeaderFields: [:], data: responseData)
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)
 
@@ -102,7 +102,7 @@ final class APIProviderTests: XCTestCase {
     }
 
     func testDownloadRequestWithResultSuccess() {
-        let response = Response(requestURL: nil, statusCode: 200, data: URL(fileURLWithPath: "randompath"))
+        let response = Response(requestURL: nil, statusCode: 200, allHeaderFields: [:], data: URL(fileURLWithPath: "randompath"))
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
 
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)
@@ -119,7 +119,7 @@ final class APIProviderTests: XCTestCase {
     }
 
     func testDownloadRequestWithProblemOnFileCreation() {
-        let response = Response<URL>(requestURL: nil, statusCode: 200, data: nil)
+        let response = Response<URL>(requestURL: nil, statusCode: 200, allHeaderFields: [:], data: nil)
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
 
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)
@@ -141,7 +141,7 @@ final class APIProviderTests: XCTestCase {
     }
 
     func testDownloadRequestWithFailure() {
-        let response = Response<URL>(requestURL: nil, statusCode: 500, data: nil)
+        let response = Response<URL>(requestURL: nil, statusCode: 500, allHeaderFields: [:], data: nil)
         let mockRequestExecutor = MockRequestExecutor(expectedResponse: Result.success(response))
 
         let apiProvider = APIProvider(configuration: configuration, requestExecutor: mockRequestExecutor)

--- a/Tests/RateLimitTests.swift
+++ b/Tests/RateLimitTests.swift
@@ -36,4 +36,15 @@ final class RateLimitTests: XCTestCase {
         XCTAssertEqual(rateLimit.entries["user-minute-lim"], 150)
         XCTAssertEqual(rateLimit.entries["user-minute-rem"], 149)
     }
+    
+    func testExtractingHeaderField() {
+        let httpUrlResponse = HTTPURLResponse(url: URL(string: "https://api.appstoreconnect.apple.com/")!, statusCode: 200, httpVersion: nil, headerFields: ["X-ratE-limiT": "user-hour-lim:3600;user-hour-rem:3545;"])
+        let rateLimit = httpUrlResponse?.rateLimit
+        XCTAssertNotNil(rateLimit)
+        if let rateLimit {
+            XCTAssertEqual(rateLimit.entries.count, 2)
+            XCTAssertEqual(rateLimit.entries["user-hour-lim"], 3600)
+            XCTAssertEqual(rateLimit.entries["user-hour-rem"], 3545)
+        }
+    }
 }

--- a/Tests/RateLimitTests.swift
+++ b/Tests/RateLimitTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class RateLimitTests: XCTestCase {
 
     func testValidValue() {
-        let rateLimit = RateLimit(value: "user-hour-lim:3600;user-hour-rem:3545;")
+        let rateLimit = RateLimit(value: "user-hour-lim:3600;user-hour-rem:3545;", requestURL: nil)
         XCTAssertNotNil(rateLimit)
         if let rateLimit {
             XCTAssertEqual(rateLimit.hourlyLimit, 3600)
@@ -20,12 +20,12 @@ final class RateLimitTests: XCTestCase {
     }
     
     func testInvalidValue() {
-        let rateLimit = RateLimit(value: "user-hour-rem:3545")
+        let rateLimit = RateLimit(value: "user-hour-rem:3545", requestURL: nil)
         XCTAssertNil(rateLimit)
     }
     
     func testModifiedValue() {
-        let rateLimit = RateLimit(value: "user-hour-rem:0;user-hour-lim:50;user-hour-new-value:10;")
+        let rateLimit = RateLimit(value: "user-hour-rem:0;user-hour-lim:50;user-hour-new-value:10;", requestURL: nil)
         XCTAssertNotNil(rateLimit)
         if let rateLimit {
             XCTAssertEqual(rateLimit.hourlyLimit, 50)

--- a/Tests/RateLimitTests.swift
+++ b/Tests/RateLimitTests.swift
@@ -12,24 +12,28 @@ final class RateLimitTests: XCTestCase {
 
     func testValidValue() {
         let rateLimit = RateLimit(value: "user-hour-lim:3600;user-hour-rem:3545;", requestURL: nil)
-        XCTAssertNotNil(rateLimit)
-        if let rateLimit {
-            XCTAssertEqual(rateLimit.hourlyLimit, 3600)
-            XCTAssertEqual(rateLimit.remainingInCurrentHour, 3545)
-        }
+        XCTAssertEqual(rateLimit.entries.count, 2)
+        XCTAssertEqual(rateLimit.entries["user-hour-lim"], 3600)
+        XCTAssertEqual(rateLimit.entries["user-hour-rem"], 3545)
     }
     
     func testInvalidValue() {
-        let rateLimit = RateLimit(value: "user-hour-rem:3545", requestURL: nil)
-        XCTAssertNil(rateLimit)
+        let rateLimit = RateLimit(value: "user-hour-rem3545", requestURL: nil)
+        XCTAssertEqual(rateLimit.entries.count, 0)
     }
     
-    func testModifiedValue() {
-        let rateLimit = RateLimit(value: "user-hour-rem:0;user-hour-lim:50;user-hour-new-value:10;", requestURL: nil)
-        XCTAssertNotNil(rateLimit)
-        if let rateLimit {
-            XCTAssertEqual(rateLimit.hourlyLimit, 50)
-            XCTAssertEqual(rateLimit.remainingInCurrentHour, 0)
-        }
+    func testPartialInvalidValue() {
+        let rateLimit = RateLimit(value: "user-hour-rem3545;user-hour-rem:3545;", requestURL: nil)
+        XCTAssertEqual(rateLimit.entries.count, 1)
+        XCTAssertEqual(rateLimit.entries["user-hour-rem"], 3545)
+    }
+    
+    func testMoreItems() {
+        let rateLimit = RateLimit(value: "user-hour-lim:3600;user-hour-rem:3598;user-minute-lim:150;user-minute-rem:149;", requestURL: nil)
+        XCTAssertEqual(rateLimit.entries.count, 4)
+        XCTAssertEqual(rateLimit.entries["user-hour-lim"], 3600)
+        XCTAssertEqual(rateLimit.entries["user-hour-rem"], 3598)
+        XCTAssertEqual(rateLimit.entries["user-minute-lim"], 150)
+        XCTAssertEqual(rateLimit.entries["user-minute-rem"], 149)
     }
 }

--- a/Tests/RateLimitTests.swift
+++ b/Tests/RateLimitTests.swift
@@ -1,0 +1,35 @@
+//
+//  RateLimitTests.swift
+//  
+//
+//  Created by Mathias Emil Mortensen on 05/04/2023.
+//
+
+import XCTest
+@testable import AppStoreConnect_Swift_SDK
+
+final class RateLimitTests: XCTestCase {
+
+    func testValidValue() {
+        let rateLimit = RateLimit(value: "user-hour-lim:3600;user-hour-rem:3545;")
+        XCTAssertNotNil(rateLimit)
+        if let rateLimit {
+            XCTAssertEqual(rateLimit.hourlyLimit, 3600)
+            XCTAssertEqual(rateLimit.remainingInCurrentHour, 3545)
+        }
+    }
+    
+    func testInvalidValue() {
+        let rateLimit = RateLimit(value: "user-hour-rem:3545")
+        XCTAssertNil(rateLimit)
+    }
+    
+    func testModifiedValue() {
+        let rateLimit = RateLimit(value: "user-hour-rem:0;user-hour-lim:50;user-hour-new-value:10;")
+        XCTAssertNotNil(rateLimit)
+        if let rateLimit {
+            XCTAssertEqual(rateLimit.hourlyLimit, 50)
+            XCTAssertEqual(rateLimit.remainingInCurrentHour, 0)
+        }
+    }
+}


### PR DESCRIPTION
APIProvider now exposes rate limit information from the `X-Rate-Limit` header field.
```swift
public let rateLimitPublisher = PassthroughSubject<RateLimit, Never>()
```

Rate limits are included in the header for every response and are enforced for all requests using the same API Key.

The documentation defines that the header info includes:
- `user-hour-lim`, which indicates the number of requests you can make per hour with the same API key.
- `user-hour-rem`, which shows the number of requests remaining.
https://developer.apple.com/documentation/appstoreconnectapi/identifying_rate_limits

However certain endpoints will also include `user-minute-lim` and `user-minute-rem`. I have filed a feedback to ask that this is added to the documentation.
Since this solution does not make assumptions about which entries are included in `X-Rate-Limit` this should not be an issue.

**Usage**
```swift
let cancellable = apiProvider.rateLimitPublisher.sink { rateLimit in
    if let remaining = rateLimit.entries["user-hour-rem"], let limit = rateLimit.entries["user-hour-lim"] {
        print("Rate limit: \(remaining)/\(limit)")
    }
}
```

**Per endpoint limits**
Rate limits apply to all requests, but it appears it is possible for certain endpoints have their own limits. Because of this I have added `requestURL` to RateLimit so you're able to see rate limits for specific endpoints.