### PR TITLE
Conforming Response to Codable

### DIFF
--- a/Sources/RequestExecutor.swift
+++ b/Sources/RequestExecutor.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The result type delivered from a successful URLRequest
-public struct Response<T> {
+public struct Response<T: Codable>: Codable {
     public typealias StatusCode = Int
 
     public let requestURL: URL?


### PR DESCRIPTION
This very small PR conforms Response object to Codable so it can be used as a generic object. 