### PR TITLE
Conforming Response to Codable

### DIFF
--- a/Sources/RateLimit.swift
+++ b/Sources/RateLimit.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct RateLimit {
+public struct RateLimit: Codable {
     /// Rate limit entries
     public let entries: [String: Int]
     

--- a/Sources/RequestExecutor.swift
+++ b/Sources/RequestExecutor.swift
@@ -11,7 +11,7 @@ import FoundationNetworking
 #endif
 
 /// The result type delivered from a successful URLRequest
-public struct Response<T> {
+public struct Response<T:Codable>: Codable{
     public typealias StatusCode = Int
 
     public let requestURL: URL?

--- a/Tests/APIProviderTests.swift
+++ b/Tests/APIProviderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class APIProviderTests: XCTestCase {
 
-    private struct MockRequestExecutor<T>: RequestExecutor {
+    private struct MockRequestExecutor<T:Codable>: RequestExecutor {
 
         let expectedResponse: Result<Response<T>, Swift.Error>
 


### PR DESCRIPTION
This very small PR conforms Response object to Codable so it can be used as a generic object.