### PR TITLE
Manually adds VISION_OS to Platform to work around OpenAPI spec issue

### DIFF
--- a/Sources/OpenAPI/Generated/Entities/Platform.swift
+++ b/Sources/OpenAPI/Generated/Entities/Platform.swift
@@ -9,4 +9,5 @@ public enum Platform: String, Codable, CaseIterable {
 	case ios = "IOS"
 	case macOs = "MAC_OS"
 	case tvOs = "TV_OS"
+    case visionOs = "VISION_OS" // VisionOS manually added since version 3.0 of Apple's OpenAPI spec fails to include it. Reported in FB13208526 27/9/2023.
 }


### PR DESCRIPTION
The OpenAPI spec 2.4 and 3.0 fails include VISION_OS in Platform. This breaks several endpoints since the API is returning VISION_OS for all apps that support VisionOS.

Example from https://api.appstoreconnect.apple.com/v1/appInfos/xxx:
```json
"platforms" : [ "IOS", "MAC_OS", "TV_OS", "VISION_OS" ]
```

Feedback filed as FB13208526.

I'm unsure how to handle this without manually modifying Platform.swift and I realize that this "fix" will be undone next time a new version of the OpenAPI spec is generated (unless Apple fixes it in that version).

Any thoughts for a better way to handle this?