### PR TITLE
Manual update for users and beta groups

### DIFF
--- a/Sources/OpenAPI/Generated/Entities/BetaGroupsWithoutIncludesResponse.swift
+++ b/Sources/OpenAPI/Generated/Entities/BetaGroupsWithoutIncludesResponse.swift
@@ -4,11 +4,11 @@
 import Foundation
 
 public struct BetaGroupsWithoutIncludesResponse: Codable {
-	public var data: [BetaTester]
+	public var data: [BetaGroup]
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public init(data: [BetaTester], links: PagedDocumentLinks, meta: PagingInformation? = nil) {
+	public init(data: [BetaGroup], links: PagedDocumentLinks, meta: PagingInformation? = nil) {
 		self.data = data
 		self.links = links
 		self.meta = meta
@@ -16,7 +16,7 @@ public struct BetaGroupsWithoutIncludesResponse: Codable {
 
 	public init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: StringCodingKey.self)
-		self.data = try values.decode([BetaTester].self, forKey: "data")
+		self.data = try values.decode([BetaGroup].self, forKey: "data")
 		self.links = try values.decode(PagedDocumentLinks.self, forKey: "links")
 		self.meta = try values.decodeIfPresent(PagingInformation.self, forKey: "meta")
 	}

--- a/Sources/OpenAPI/Generated/Entities/BetaTestersWithoutIncludesResponse.swift
+++ b/Sources/OpenAPI/Generated/Entities/BetaTestersWithoutIncludesResponse.swift
@@ -4,11 +4,11 @@
 import Foundation
 
 public struct BetaTestersWithoutIncludesResponse: Codable {
-	public var data: [Build]
+	public var data: [BetaTester]
 	public var links: PagedDocumentLinks
 	public var meta: PagingInformation?
 
-	public init(data: [Build], links: PagedDocumentLinks, meta: PagingInformation? = nil) {
+	public init(data: [BetaTester], links: PagedDocumentLinks, meta: PagingInformation? = nil) {
 		self.data = data
 		self.links = links
 		self.meta = meta
@@ -16,7 +16,7 @@ public struct BetaTestersWithoutIncludesResponse: Codable {
 
 	public init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: StringCodingKey.self)
-		self.data = try values.decode([Build].self, forKey: "data")
+		self.data = try values.decode([BetaTester].self, forKey: "data")
 		self.links = try values.decode(PagedDocumentLinks.self, forKey: "links")
 		self.meta = try values.decodeIfPresent(PagingInformation.self, forKey: "meta")
 	}

--- a/Sources/OpenAPI/Generated/Entities/UserRole.swift
+++ b/Sources/OpenAPI/Generated/Entities/UserRole.swift
@@ -17,4 +17,5 @@ public enum UserRole: String, Codable, CaseIterable {
 	case createApps = "CREATE_APPS"
 	case cloudManagedDeveloperID = "CLOUD_MANAGED_DEVELOPER_ID"
 	case cloudManagedAppDistribution = "CLOUD_MANAGED_APP_DISTRIBUTION"
+	case generateIndividualKeys = "GENERATE_INDIVIDUAL_KEYS"
 }

--- a/Sources/OpenAPI/Generated/Paths/PathsV1UserInvitations.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1UserInvitations.swift
@@ -42,6 +42,7 @@ extension APIEndpoint.V1 {
 				case createApps = "CREATE_APPS"
 				case cloudManagedDeveloperID = "CLOUD_MANAGED_DEVELOPER_ID"
 				case cloudManagedAppDistribution = "CLOUD_MANAGED_APP_DISTRIBUTION"
+				case generateIndividualKeys = "GENERATE_INDIVIDUAL_KEYS"
 			}
 
 			public enum Sort: String, Codable, CaseIterable {

--- a/Sources/OpenAPI/Generated/Paths/PathsV1Users.swift
+++ b/Sources/OpenAPI/Generated/Paths/PathsV1Users.swift
@@ -42,6 +42,7 @@ extension APIEndpoint.V1 {
 				case createApps = "CREATE_APPS"
 				case cloudManagedDeveloperID = "CLOUD_MANAGED_DEVELOPER_ID"
 				case cloudManagedAppDistribution = "CLOUD_MANAGED_APP_DISTRIBUTION"
+				case generateIndividualKeys = "GENERATE_INDIVIDUAL_KEYS"
 			}
 
 			public enum Sort: String, Codable, CaseIterable {

--- a/Sources/OpenAPI/app_store_connect_api.json
+++ b/Sources/OpenAPI/app_store_connect_api.json
@@ -41049,7 +41049,8 @@
                   "IMAGE_MANAGER",
                   "CREATE_APPS",
                   "CLOUD_MANAGED_DEVELOPER_ID",
-                  "CLOUD_MANAGED_APP_DISTRIBUTION"
+                  "CLOUD_MANAGED_APP_DISTRIBUTION",
+                  "GENERATE_INDIVIDUAL_KEYS"
                 ]
               }
             },
@@ -41562,7 +41563,8 @@
                   "IMAGE_MANAGER",
                   "CREATE_APPS",
                   "CLOUD_MANAGED_DEVELOPER_ID",
-                  "CLOUD_MANAGED_APP_DISTRIBUTION"
+                  "CLOUD_MANAGED_APP_DISTRIBUTION",
+                  "GENERATE_INDIVIDUAL_KEYS"
                 ]
               }
             },
@@ -130334,7 +130336,7 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/BetaTester"
+              "$ref": "#/components/schemas/BetaGroup"
             }
           },
           "links": {
@@ -130542,7 +130544,7 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Build"
+              "$ref": "#/components/schemas/BetaTester"
             }
           },
           "links": {
@@ -134467,7 +134469,8 @@
           "IMAGE_MANAGER",
           "CREATE_APPS",
           "CLOUD_MANAGED_DEVELOPER_ID",
-          "CLOUD_MANAGED_APP_DISTRIBUTION"
+          "CLOUD_MANAGED_APP_DISTRIBUTION",
+          "GENERATE_INDIVIDUAL_KEYS"
         ]
       },
       "csv": {


### PR DESCRIPTION
This MR fixes issues in Apple's API Spec:

- Added missing user role enum case: `GENERATE_INDIVIDUAL_KEYS`
- Updated BetaGroup EP to return array of BetaGroups and not BetaTesters
- Updated BetaTesters EP to return array of BetaTesters and not Builds.

That may not be all of those issues, just the ones I encountered.