### PR TITLE
fix: Update api spec and generate code for MetricInsight;

### DIFF
--- a/Sources/OpenAPI/Generated/Entities/MetricsInsight.swift
+++ b/Sources/OpenAPI/Generated/Entities/MetricsInsight.swift
@@ -8,7 +8,7 @@ public struct MetricsInsight: Codable {
 	public var latestVersion: String?
 	public var metric: String?
 	public var summaryString: String?
-	public var referenceVersions: String?
+	public var referenceVersions: [String]?
 	public var maxLatestVersionValue: Double?
 	public var subSystemLabel: String?
 	public var isHighImpact: Bool?
@@ -52,7 +52,7 @@ public struct MetricsInsight: Codable {
 		}
 	}
 
-	public init(metricCategory: MetricCategory? = nil, latestVersion: String? = nil, metric: String? = nil, summaryString: String? = nil, referenceVersions: String? = nil, maxLatestVersionValue: Double? = nil, subSystemLabel: String? = nil, isHighImpact: Bool? = nil, populations: [Population]? = nil) {
+	public init(metricCategory: MetricCategory? = nil, latestVersion: String? = nil, metric: String? = nil, summaryString: String? = nil, referenceVersions: [String]? = nil, maxLatestVersionValue: Double? = nil, subSystemLabel: String? = nil, isHighImpact: Bool? = nil, populations: [Population]? = nil) {
 		self.metricCategory = metricCategory
 		self.latestVersion = latestVersion
 		self.metric = metric
@@ -70,7 +70,7 @@ public struct MetricsInsight: Codable {
 		self.latestVersion = try values.decodeIfPresent(String.self, forKey: "latestVersion")
 		self.metric = try values.decodeIfPresent(String.self, forKey: "metric")
 		self.summaryString = try values.decodeIfPresent(String.self, forKey: "summaryString")
-		self.referenceVersions = try values.decodeIfPresent(String.self, forKey: "referenceVersions")
+		self.referenceVersions = try values.decodeIfPresent([String].self, forKey: "referenceVersions")
 		self.maxLatestVersionValue = try values.decodeIfPresent(Double.self, forKey: "maxLatestVersionValue")
 		self.subSystemLabel = try values.decodeIfPresent(String.self, forKey: "subSystemLabel")
 		self.isHighImpact = try values.decodeIfPresent(Bool.self, forKey: "highImpact")

--- a/Sources/OpenAPI/Generated/Entities/XcodeMetrics.swift
+++ b/Sources/OpenAPI/Generated/Entities/XcodeMetrics.swift
@@ -126,10 +126,10 @@ public struct XcodeMetrics: Codable {
 						public var version: String?
 						public var value: Double?
 						public var errorMargin: Double?
-						public var percentageBreakdown: PercentageBreakdown?
+						public var percentageBreakdown: [PercentageBreakdownItem]?
 						public var goal: String?
 
-						public struct PercentageBreakdown: Codable {
+						public struct PercentageBreakdownItem: Codable {
 							public var value: Double?
 							public var subSystemLabel: String?
 
@@ -151,7 +151,7 @@ public struct XcodeMetrics: Codable {
 							}
 						}
 
-						public init(version: String? = nil, value: Double? = nil, errorMargin: Double? = nil, percentageBreakdown: PercentageBreakdown? = nil, goal: String? = nil) {
+						public init(version: String? = nil, value: Double? = nil, errorMargin: Double? = nil, percentageBreakdown: [PercentageBreakdownItem]? = nil, goal: String? = nil) {
 							self.version = version
 							self.value = value
 							self.errorMargin = errorMargin
@@ -164,7 +164,7 @@ public struct XcodeMetrics: Codable {
 							self.version = try values.decodeIfPresent(String.self, forKey: "version")
 							self.value = try values.decodeIfPresent(Double.self, forKey: "value")
 							self.errorMargin = try values.decodeIfPresent(Double.self, forKey: "errorMargin")
-							self.percentageBreakdown = try values.decodeIfPresent(PercentageBreakdown.self, forKey: "percentageBreakdown")
+							self.percentageBreakdown = try values.decodeIfPresent([PercentageBreakdownItem].self, forKey: "percentageBreakdown")
 							self.goal = try values.decodeIfPresent(String.self, forKey: "goal")
 						}
 

--- a/Sources/OpenAPI/app_store_connect_api.json
+++ b/Sources/OpenAPI/app_store_connect_api.json
@@ -133995,7 +133995,10 @@
             "type": "string"
           },
           "referenceVersions": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "maxLatestVersionValue": {
             "type": "number"

--- a/Sources/OpenAPI/app_store_connect_api.json
+++ b/Sources/OpenAPI/app_store_connect_api.json
@@ -134693,15 +134693,18 @@
                                           "type": "number"
                                         },
                                         "percentageBreakdown": {
-                                          "type": "object",
-                                          "properties": {
-                                            "value": {
-                                              "type": "number"
-                                            },
-                                            "subSystemLabel": {
-                                              "type": "string"
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "value": {
+                                                 "type": "number"
+                                              },
+                                              "subSystemLabel": {
+                                                 "type": "string"
+                                              }
                                             }
-                                          }
+                                           }
                                         },
                                         "goal": {
                                           "type": "string"


### PR DESCRIPTION
This is a manual update of the spec, because the spec is incorrect;

This PR fixes issues in Apple's API Spec:

-  The `referenceVersions` in the spec from apple lists only a `String` but the real response is a array of `Strings`.
-  The `percentageBreakdown` in the spec from apple lists only 1 object but the realresponse is an array of `PercentageBreakdownItem`.
