### PR TITLE
Modify JWT access level to public

### DIFF
--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -50,7 +50,7 @@ protocol JWTCreatable {
     func signedToken(using privateKey: JWT.PrivateKey) throws -> JWT.Token
 }
 
-struct JWT: Codable, JWTCreatable {
+public struct JWT: Codable, JWTCreatable {
 
     public enum Error: Swift.Error, LocalizedError {
 
@@ -70,8 +70,8 @@ struct JWT: Codable, JWTCreatable {
         }
     }
 
-    typealias Token = String
-    typealias PrivateKey = P256.Signing.PrivateKey
+    public typealias Token = String
+    public typealias PrivateKey = P256.Signing.PrivateKey
 
     typealias DateProvider = () -> Date
     static let defaultDateProvider: DateProvider = {


### PR DESCRIPTION
Can catch let error as JWT.Error, get correct error localizedDescription

Example code:
```swift
    do {
      let config = try APIConfiguration(issuerID: "", privateKeyID: "", privateKey: "")
    } catch let error as JWT.Error {
      print("JWT.Error: \(error.localizedDescription)")
    } catch {
      print(error.localizedDescription)
    }
```

Output:
```
JWT.Error: The private key is not valid
```

If use normal catch:
```swift
    do {
      let config = try APIConfiguration(issuerID: "", privateKeyID: "", privateKey: "")
    } catch {
      print(error.localizedDescription)
    }
```

Output:
```
The operation couldn’t be completed. (AppStoreConnect_Swift_SDK.JWT.Error error 2.)
```