### PR TITLE
Manual patch CiGitUser.avatarUrl type

### DIFF
--- a/Sources/OpenAPI/Generated/Entities/CiGitUser.swift
+++ b/Sources/OpenAPI/Generated/Entities/CiGitUser.swift
@@ -5,9 +5,9 @@ import Foundation
 
 public struct CiGitUser: Codable {
 	public var displayName: String?
-	public var avatarURL: URL?
+	public var avatarURL: String?
 
-	public init(displayName: String? = nil, avatarURL: URL? = nil) {
+	public init(displayName: String? = nil, avatarURL: String? = nil) {
 		self.displayName = displayName
 		self.avatarURL = avatarURL
 	}
@@ -15,7 +15,7 @@ public struct CiGitUser: Codable {
 	public init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: StringCodingKey.self)
 		self.displayName = try values.decodeIfPresent(String.self, forKey: "displayName")
-		self.avatarURL = try values.decodeIfPresent(URL.self, forKey: "avatarUrl")
+		self.avatarURL = try values.decodeIfPresent(String.self, forKey: "avatarUrl")
 	}
 
 	public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
`avatarUrl` is currently of type URL, but oftentimes the JSON returned contains an empty string `""`. This causes the URL decoding to fail with "invalid URL". Switching this to type String seems like the least intrusive fix.
