### PR TITLE
Add missing bundle id platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ update: download generate
 # see https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/197
 .PHONY: download
 download:
-	curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL" ] | .paths."/v1/certificates".get.parameters = (.paths."/v1/certificates".get.parameters | map(if .name == "filter[certificateType]" then .schema.items.enum += ["DEVELOPER_ID_APPLICATION_G2"] else . end)) | .components.schemas.CertificateType.enum += ["DEVELOPER_ID_APPLICATION_G2"] | del(.["x-important"]) | del(.. |."enum"? | select(. != null and length == 0))' > Sources/OpenAPI/app_store_connect_api.json
+	curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL", "SERVICES" ] | .paths."/v1/certificates".get.parameters = (.paths."/v1/certificates".get.parameters | map(if .name == "filter[certificateType]" then .schema.items.enum += ["DEVELOPER_ID_APPLICATION_G2"] else . end)) | .components.schemas.CertificateType.enum += ["DEVELOPER_ID_APPLICATION_G2"] | del(.["x-important"]) | del(.. |."enum"? | select(. != null and length == 0))' > Sources/OpenAPI/app_store_connect_api.json
 
 # Runs the CreateAPI generator to update generated source code
 .PHONY: generate

--- a/Sources/OpenAPI/Generated/Entities/BundleIDPlatform.swift
+++ b/Sources/OpenAPI/Generated/Entities/BundleIDPlatform.swift
@@ -7,4 +7,5 @@ public enum BundleIDPlatform: String, Codable, CaseIterable {
 	case ios = "IOS"
 	case macOs = "MAC_OS"
 	case universal = "UNIVERSAL"
+	case services = "SERVICES"
 }


### PR DESCRIPTION
The Apple OpenAPI spec is missing another value. This is marked WIP as this was built on top of my previous PR in order to move my own project forward, as such it currently contains the changes made in that PR. Once https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/266 has been merged this will reflect the new change and can also be merged (assuming everything still passes etc).
