### PR TITLE
Fix date parsing for certain environments

### DIFF
--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -119,6 +119,12 @@ public final class APIProvider {
             if let date = formatter.date(from: dateStr) {
                 return date
             }
+            // Example: 2024-01-01T23:59:59.000+00:00
+            let isoDateFormatter = ISO8601DateFormatter()
+            isoDateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = isoDateFormatter.date(from: dateStr) {
+                return date
+            }
             throw APIProvider.Error.dateDecodingError(dateStr)
         })
         return decoder


### PR DESCRIPTION
There were 2 users (in a certain company where I work, which is a very small fraction of users) who experienced this issue, they had some specific environment, we did not check which environment they had or why this code works, we only know that it solves the issue.

The fix may look bad, since it's the 4th way of parse the date, however, there were already 3 ways of parsing it. The reason I make this PR is that it would be great to not use a fork of this repository in our company.