### PR TITLE
Update AppStoreVersionPhasedReleaseWithoutIncludesResponse.swift

### DIFF
--- a/Sources/OpenAPI/Generated/Entities/AppStoreVersionPhasedReleaseWithoutIncludesResponse.swift
+++ b/Sources/OpenAPI/Generated/Entities/AppStoreVersionPhasedReleaseWithoutIncludesResponse.swift
@@ -5,17 +5,17 @@ import Foundation
 
 public struct AppStoreVersionPhasedReleaseWithoutIncludesResponse: Codable {
 	/// AppStoreVersion
-	public var data: AppStoreVersion
+	public var data: AppStoreVersionPhasedRelease
 	public var links: DocumentLinks
 
-	public init(data: AppStoreVersion, links: DocumentLinks) {
+	public init(data: AppStoreVersionPhasedRelease, links: DocumentLinks) {
 		self.data = data
 		self.links = links
 	}
 
 	public init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: StringCodingKey.self)
-		self.data = try values.decode(AppStoreVersion.self, forKey: "data")
+		self.data = try values.decode(AppStoreVersionPhasedRelease.self, forKey: "data")
 		self.links = try values.decode(DocumentLinks.self, forKey: "links")
 	}
 


### PR DESCRIPTION
Currently receiving this response would result in decode crash, using correct data structure would resolve this, this may also be the case for some other endpoints, but i am not sure

(crashed due to type not parsing appStoreVersionPhasedReleases due to AppStoreVersion only expecting appStoreVersion)