### PR TITLE
Allow customisation of JWT expiration duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Copy the contents and remove the whitelines, `-----BEGIN PRIVATE KEY-----` and `
 Use this private key together with the issuer ID and the private key ID to create your configuration file:
 
 ```swift
-let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKey: "<YOUR PRIVATE KEY>")
+let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKey: "<YOUR PRIVATE KEY>", expirationDuration: "<OPTIONAL EXPIRE DURATION>")
 ```
 
 Alternatively you can pass the path to the .p8 file:
 
 ```swift
-let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKeyURL: URL(fileURLWithPath: "~/AuthKey_<YOUR PRIVATE KEY ID>.p8"))
+let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKeyURL: URL(fileURLWithPath: "~/AuthKey_<YOUR PRIVATE KEY ID>.p8"), expirationDuration: "<OPTIONAL EXPIRE DURATION>")
 ```
 
 You can even omit the `privateKeyID` as it can be inferred from the name of the .p8 file.

--- a/README.md
+++ b/README.md
@@ -46,13 +46,20 @@ Copy the contents and remove the whitelines, `-----BEGIN PRIVATE KEY-----` and `
 Use this private key together with the issuer ID and the private key ID to create your configuration file:
 
 ```swift
-let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKey: "<YOUR PRIVATE KEY>", expirationDuration: "<OPTIONAL EXPIRE DURATION>")
+let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKey: "<YOUR PRIVATE KEY>")
 ```
 
 Alternatively you can pass the path to the .p8 file:
 
 ```swift
-let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKeyURL: URL(fileURLWithPath: "~/AuthKey_<YOUR PRIVATE KEY ID>.p8"), expirationDuration: "<OPTIONAL EXPIRE DURATION>")
+let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKeyURL: URL(fileURLWithPath: "~/AuthKey_<YOUR PRIVATE KEY ID>.p8"))
+```
+
+Both methods also accept an optional `expirationDuration` parameter that defaults to 20 minutes which is the max duration allowed by the API. In some cases it might be useful to specify a shorter value in seconds to account for possible clock skews:
+
+```swift
+APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKey: "<YOUR PRIVATE KEY>", expirationDuration: "<OPTIONAL EXPIRATION DURATION>"))
+APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKeyURL: URL(fileURLWithPath: "~/AuthKey_<YOUR PRIVATE KEY ID>.p8"), expirationDuration: "<OPTIONAL EXPIRATION DURATION>")
 ```
 
 You can even omit the `privateKeyID` as it can be inferred from the name of the .p8 file.

--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -38,7 +38,7 @@ public struct APIConfiguration {
     ///   - issuerID: Your issuer ID from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
     ///   - privateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
     ///   - privateKey: Your private key stripped out of the -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY----- lines.
-    ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
+    ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes. Defaults to 20 minutes.
     public init(issuerID: String, privateKeyID: String, privateKey: String, expirationDuration: TimeInterval = 60 * 20) throws {
         self.privateKeyID = privateKeyID
         self.issuerID = issuerID
@@ -59,7 +59,7 @@ public struct APIConfiguration {
     ///   - issuerID: Your issuer ID from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
     ///   - privateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34). Will be inferred from `privateKeyURL` if nil.
     ///   - privateKeyURL: A file URL that references the path to your private key file.
-    ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
+    ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes. Defaults to 20 minutes.
     public init(issuerID: String, privateKeyID: String? = nil, privateKeyURL: URL, expirationDuration: TimeInterval = 60 * 20) throws {
         self.issuerID = issuerID
         if let privateKeyID = privateKeyID {

--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -32,6 +32,9 @@ public struct APIConfiguration {
     /// The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
     let expirationDuration: TimeInterval
 
+    /// The range of values allowed for the expiration duration of the token.
+    private let allowedExpirationDurationRange: ClosedRange<TimeInterval> = 0...1200
+
     /// Creates a new API configuration to use for initialising the API Provider.
     ///
     /// - Parameters:
@@ -49,6 +52,9 @@ public struct APIConfiguration {
             self.privateKey = try JWT.PrivateKey(derRepresentation: base64Key)
         } catch {
             throw JWT.Error.invalidPrivateKey
+        }
+        guard allowedExpirationDurationRange ~= expirationDuration else {
+            throw JWT.Error.invalidExpirationDuration
         }
         self.expirationDuration = expirationDuration
     }
@@ -73,6 +79,9 @@ public struct APIConfiguration {
             self.privateKey = try JWT.PrivateKey(pemRepresentation: pemEncodedPrivateKey)
         } catch {
             throw JWT.Error.invalidPrivateKey
+        }
+        guard allowedExpirationDurationRange ~= expirationDuration else {
+            throw JWT.Error.invalidExpirationDuration
         }
         self.expirationDuration = expirationDuration
     }

--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -29,15 +29,19 @@ public struct APIConfiguration {
     /// Your issuer ID from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
     let issuerID: String
 
+    /// The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
+    let expirationDuration: TimeInterval
+
     /// Creates a new API configuration to use for initialising the API Provider.
     ///
     /// - Parameters:
-    ///   - privateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
     ///   - issuerID: Your issuer ID from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
-    public init(issuerID: String, privateKeyID: String, privateKey: String) throws {
+    ///   - privateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
+    ///   - privateKey: Your private key stripped out of the -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY----- lines.
+    ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
+    public init(issuerID: String, privateKeyID: String, privateKey: String, expirationDuration: TimeInterval = 60 * 20) throws {
         self.privateKeyID = privateKeyID
         self.issuerID = issuerID
-
         guard let base64Key = Data(base64Encoded: privateKey) else {
             throw JWT.Error.invalidBase64EncodedPrivateKey
         }
@@ -46,6 +50,7 @@ public struct APIConfiguration {
         } catch {
             throw JWT.Error.invalidPrivateKey
         }
+        self.expirationDuration = expirationDuration
     }
     
     /// Creates a new API configuration to use for initialising the API Provider.
@@ -54,7 +59,8 @@ public struct APIConfiguration {
     ///   - issuerID: Your issuer ID from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
     ///   - privateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34). Will be inferred from `privateKeyURL` if nil.
     ///   - privateKeyURL: A file URL that references the path to your private key file.
-    public init(issuerID: String, privateKeyID: String? = nil, privateKeyURL: URL) throws {
+    ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
+    public init(issuerID: String, privateKeyID: String? = nil, privateKeyURL: URL, expirationDuration: TimeInterval = 60 * 20) throws {
         self.issuerID = issuerID
         if let privateKeyID = privateKeyID {
             self.privateKeyID = privateKeyID
@@ -68,6 +74,7 @@ public struct APIConfiguration {
         } catch {
             throw JWT.Error.invalidPrivateKey
         }
+        self.expirationDuration = expirationDuration
     }
 }
 

--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -84,7 +84,7 @@ public struct JWT: Codable, JWTCreatable {
     /// Your issuer identifier from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
     private let issuerIdentifier: String
 
-    /// The token's expiration duration. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
+    /// The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
     private let expireDuration: TimeInterval
 
     /// Creates a new JWT Factory to create signed requests for the App Store Connect API.
@@ -92,8 +92,7 @@ public struct JWT: Codable, JWTCreatable {
     /// - Parameters:
     ///   - keyIdentifier: Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
     ///   - issuerIdentifier: Your issuer identifier from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
-    ///   - expireDuration: The token's expiration duration.
-    ///   Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
+    ///   - expireDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
     public init(keyIdentifier: String, issuerIdentifier: String, expireDuration: TimeInterval) {
         header = Header(keyIdentifier: keyIdentifier)
         self.issuerIdentifier = issuerIdentifier

--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -54,16 +54,19 @@ public struct JWT: Codable, JWTCreatable {
 
     public enum Error: Swift.Error, LocalizedError {
 
-        case invalidDigest
         case invalidBase64EncodedPrivateKey
+        case invalidDigest
+        case invalidExpirationDuration
         case invalidPrivateKey
 
         public var localizedDescription: String {
             switch self {
-            case .invalidDigest:
-                return "Failed to generate a digest"
             case .invalidBase64EncodedPrivateKey:
                 return "The private key is not encoded in Base64 format"
+            case .invalidDigest:
+                return "Failed to generate a digest"
+            case .invalidExpirationDuration:
+                return "The expiration duration must be between 0 and 20 minutes (1200 seconds)"
             case .invalidPrivateKey:
                 return "The private key is not valid"
             }

--- a/Sources/JWT/JWTRequestsAuthenticator.swift
+++ b/Sources/JWT/JWTRequestsAuthenticator.swift
@@ -22,7 +22,7 @@ final class JWTRequestsAuthenticator {
 
     init(apiConfiguration: APIConfiguration) {
         self.apiConfiguration = apiConfiguration
-        self.jwtCreator = JWT(keyIdentifier: apiConfiguration.privateKeyID, issuerIdentifier: apiConfiguration.issuerID, expireDuration: 60 * 20)
+        self.jwtCreator = JWT(keyIdentifier: apiConfiguration.privateKeyID, issuerIdentifier: apiConfiguration.issuerID, expireDuration: apiConfiguration.expirationDuration)
     }
 
     /// Generates a new JWT Token, but only if the in memory cached one is not expired.

--- a/Tests/APIConfigurationTests.swift
+++ b/Tests/APIConfigurationTests.swift
@@ -26,7 +26,7 @@ final class APIConfigurationTests: XCTestCase {
         let nonBase64Key = "&^&%^$%$%"
         XCTAssertThrowsError(try APIConfiguration(issuerID: issuerID,
                                                   privateKeyID: privateKeyID,
-                                                  privateKey: nonBase64Key)) { (error) in
+                                                  privateKey: nonBase64Key)) { error in
             XCTAssertEqual(error as! JWT.Error, JWT.Error.invalidBase64EncodedPrivateKey)
         }
     }
@@ -35,9 +35,17 @@ final class APIConfigurationTests: XCTestCase {
         let invalidKey = "QSBrZXk=" // "A key"
         XCTAssertThrowsError(try APIConfiguration(issuerID: issuerID,
                                                   privateKeyID: privateKeyID,
-                                                  privateKey: invalidKey)) { (error) in
+                                                  privateKey: invalidKey)) { error in
             XCTAssertEqual(error as! JWT.Error, JWT.Error.invalidPrivateKey)
         }
     }
 
+    func testInvalidExpirationDuration() throws {
+        XCTAssertThrowsError(try APIConfiguration(issuerID: issuerID,
+                                                  privateKeyID: privateKeyID,
+                                                  privateKey: privateKey,
+                                                  expirationDuration: 60 * 30)) { error in
+            XCTAssertEqual(error as! JWT.Error, JWT.Error.invalidExpirationDuration)
+        }
+    }
 }


### PR DESCRIPTION
This PR allows customizing the expiration duration of the token in `APIConfiguration`. This is to account for possible clock skews.

From the documentation:

> exp - Expiration Time | The token’s expiration time in Unix epoch time. Tokens that expire more than 20 minutes into the future are not valid except for resources listed in Determine the Appropriate Token Lifetime.

Source: [Generating Tokens for API Requests](https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests)

Using the default value of 20 minutes might be too strict in cases where there is a slight clock difference between the client and the server (where the clock of the client machine is slightly ahead of the clock of the server), resulting in the server refusing the request with the following API error:

```
Error: Request https://api.appstoreconnect.apple.com/v1/users?<REDACTED> failed with status code 401. Related response error(s):

The request failed with response code 401 NOT_AUTHORIZED

Authentication credentials are missing or invalid.. Provide a properly configured and signed bearer token, and make sure that it has not expired. Learn more about Generating Tokens for API Requests https://developer.apple.com/go/?id=api-generating-tokens).
```

The error above can easily be reproduce by fabricating a skewed date in `JWT.swift` while leaving the default expiration duration of 20 minutes:

```
static let defaultDateProvider: DateProvider = {
    Date().addingTimeInterval(60)
}
```

These changes maintain backward compatibility.