### PR TITLE
Added missing value “SERVICES” to BundleIDPlatform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ update: download generate
 # see https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/197
 .PHONY: download
 download:
-	curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL" ] | .paths."/v1/certificates".get.parameters = (.paths."/v1/certificates".get.parameters | map(if .name == "filter[certificateType]" then .schema.items.enum += ["DEVELOPER_ID_APPLICATION_G2"] else . end)) | .components.schemas.CertificateType.enum += ["DEVELOPER_ID_APPLICATION_G2"] | del(.["x-important"]) | del(.. |."enum"? | select(. != null and length == 0))' > Sources/OpenAPI/app_store_connect_api.json
+	curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL", "SERVICES" ] | .paths."/v1/certificates".get.parameters = (.paths."/v1/certificates".get.parameters | map(if .name == "filter[certificateType]" then .schema.items.enum += ["DEVELOPER_ID_APPLICATION_G2"] else . end)) | .components.schemas.CertificateType.enum += ["DEVELOPER_ID_APPLICATION_G2"] | del(.["x-important"]) | del(.. |."enum"? | select(. != null and length == 0))' > Sources/OpenAPI/app_store_connect_api.json
 
 # Runs the CreateAPI generator to update generated source code
 .PHONY: generate

--- a/Sources/OpenAPI/Generated/Entities/BundleIDPlatform.swift
+++ b/Sources/OpenAPI/Generated/Entities/BundleIDPlatform.swift
@@ -7,4 +7,5 @@ public enum BundleIDPlatform: String, Codable, CaseIterable {
 	case ios = "IOS"
 	case macOs = "MAC_OS"
 	case universal = "UNIVERSAL"
+	case services = "SERVICES"
 }


### PR DESCRIPTION
This is really just re-adding [this PR](https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/267). These modifications easily got lost on updating the API spec from Apple (if Apple haven't fixed the issue). 

Perhaps a solution to this ongoing situation would be adding some kind of mechanism to reapply modifications to the JSON spec before code generation (and remove them as Apple fix them). I'll perhaps try and look in to that if i can find some spare time. 