### PR TITLE
Adding support for Key IDs longer than 10 characters

### DIFF
--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -122,7 +122,7 @@ public struct APIConfiguration {
             self.privateKeyID = individualPrivateKeyID
         } else {
             let filename = privateKeyURL.deletingPathExtension().lastPathComponent
-            self.privateKeyID = String(filename.suffix(10))
+            self.privateKeyID = String(filename.reversed().prefix(while: { $0 != "_" }).reversed())
         }
         do {
             let pemEncodedPrivateKey = try String(contentsOf: privateKeyURL)


### PR DESCRIPTION
It seems that for individual API keys the Key ID can be longer than 10 characters, so this is necessary (provided the naming scheme of `ApiKey_<keyId>.p8` remains stable).

The `reversed()` dance could be avoided by introducing a dependency on [swift-algorithms](https://github.com/apple/swift-algorithms/tree/main) which provides `suffix(while:)`.