### PR TITLE
Adds patches to make sure no regressions occur to spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ update: download generate
 .PHONY: download
 download:
 	curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL", "SERVICES" ] | del(.["x-important"]) | del(.. |."enum"? | select(. != null and length == 0)) | .components.schemas.AppEvent.properties.attributes.properties.deepLink.format = null | .components.schemas.AppEvent.properties.attributes.properties.deepLink.type = "string"' > Sources/OpenAPI/app_store_connect_api.json
+	patch -p1 < Sources/OpenAPI/patches/v4.0.0.patch
 
 # Runs the CreateAPI generator to update generated source code
 .PHONY: generate

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ update: download generate
 # see https://github.com/AvdLee/appstoreconnect-swift-sdk/pull/197
 .PHONY: download
 download:
-	curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL", "SERVICES" ] | del(.["x-important"]) | del(.. |."enum"? | select(. != null and length == 0))' > Sources/OpenAPI/app_store_connect_api.json
+	curl -fsSL -o - https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip | bsdtar -xOf - | jq '.components.schemas.BundleIdPlatform.enum |= [ "IOS", "MAC_OS", "UNIVERSAL", "SERVICES" ] | del(.["x-important"]) | del(.. |."enum"? | select(. != null and length == 0)) | .components.schemas.AppEvent.properties.attributes.properties.deepLink.format = null | .components.schemas.AppEvent.properties.attributes.properties.deepLink.type = "string"' > Sources/OpenAPI/app_store_connect_api.json
 
 # Runs the CreateAPI generator to update generated source code
 .PHONY: generate

--- a/Sources/OpenAPI/Generated/Entities/AppEvent.swift
+++ b/Sources/OpenAPI/Generated/Entities/AppEvent.swift
@@ -18,7 +18,7 @@ public struct AppEvent: Codable, Identifiable {
 		public var referenceName: String?
 		public var badge: Badge?
 		public var eventState: EventState?
-		public var deepLink: URL?
+		public var deepLink: String?
 		public var purchaseRequirement: String?
 		public var primaryLocale: String?
 		public var priority: Priority?
@@ -121,7 +121,7 @@ public struct AppEvent: Codable, Identifiable {
 			}
 		}
 
-		public init(referenceName: String? = nil, badge: Badge? = nil, eventState: EventState? = nil, deepLink: URL? = nil, purchaseRequirement: String? = nil, primaryLocale: String? = nil, priority: Priority? = nil, purpose: Purpose? = nil, territorySchedules: [TerritorySchedule]? = nil, archivedTerritorySchedules: [ArchivedTerritorySchedule]? = nil) {
+		public init(referenceName: String? = nil, badge: Badge? = nil, eventState: EventState? = nil, deepLink: String? = nil, purchaseRequirement: String? = nil, primaryLocale: String? = nil, priority: Priority? = nil, purpose: Purpose? = nil, territorySchedules: [TerritorySchedule]? = nil, archivedTerritorySchedules: [ArchivedTerritorySchedule]? = nil) {
 			self.referenceName = referenceName
 			self.badge = badge
 			self.eventState = eventState
@@ -139,7 +139,7 @@ public struct AppEvent: Codable, Identifiable {
 			self.referenceName = try values.decodeIfPresent(String.self, forKey: "referenceName")
 			self.badge = try values.decodeIfPresent(Badge.self, forKey: "badge")
 			self.eventState = try values.decodeIfPresent(EventState.self, forKey: "eventState")
-			self.deepLink = try values.decodeIfPresent(URL.self, forKey: "deepLink")
+			self.deepLink = try values.decodeIfPresent(String.self, forKey: "deepLink")
 			self.purchaseRequirement = try values.decodeIfPresent(String.self, forKey: "purchaseRequirement")
 			self.primaryLocale = try values.decodeIfPresent(String.self, forKey: "primaryLocale")
 			self.priority = try values.decodeIfPresent(Priority.self, forKey: "priority")

--- a/Sources/OpenAPI/patches/v4.0.0.patch
+++ b/Sources/OpenAPI/patches/v4.0.0.patch
@@ -1,0 +1,162 @@
+--- a/Sources/OpenAPI/app_store_connect_api.json
++++ b/Sources/OpenAPI/app_store_connect_api.json
+@@ -9787,6 +9787,7 @@
+                   "violenceCartoonOrFantasy",
+                   "violenceRealisticProlongedGraphicOrSadistic",
+                   "violenceRealistic",
++                  "ageRatingOverride",
+                   "koreaAgeRatingOverride"
+                 ]
+               }
+@@ -15399,6 +15400,7 @@
+                   "violenceCartoonOrFantasy",
+                   "violenceRealisticProlongedGraphicOrSadistic",
+                   "violenceRealistic",
++                  "ageRatingOverride",
+                   "koreaAgeRatingOverride"
+                 ]
+               }
+@@ -58365,6 +58367,7 @@
+                   "duration",
+                   "offerMode",
+                   "numberOfPeriods",
++                  "totalNumberOfCodes",
+                   "active",
+                   "subscription",
+                   "oneTimeUseCodes",
+@@ -59714,6 +59717,7 @@
+                   "duration",
+                   "offerMode",
+                   "numberOfPeriods",
++                  "totalNumberOfCodes",
+                   "active",
+                   "subscription",
+                   "oneTimeUseCodes",
+@@ -65717,6 +65721,7 @@
+                   "violenceCartoonOrFantasy",
+                   "violenceRealisticProlongedGraphicOrSadistic",
+                   "violenceRealistic",
++                  "ageRatingOverride",
+                   "koreaAgeRatingOverride"
+                 ]
+               }
+@@ -69645,6 +69650,7 @@
+                   "violenceCartoonOrFantasy",
+                   "violenceRealisticProlongedGraphicOrSadistic",
+                   "violenceRealistic",
++                  "ageRatingOverride",
+                   "koreaAgeRatingOverride"
+                 ]
+               }
+@@ -75869,6 +75875,7 @@
+                   "violenceCartoonOrFantasy",
+                   "violenceRealisticProlongedGraphicOrSadistic",
+                   "violenceRealistic",
++                  "ageRatingOverride",
+                   "koreaAgeRatingOverride"
+                 ]
+               }
+@@ -82154,6 +82161,7 @@
+                   "violenceCartoonOrFantasy",
+                   "violenceRealisticProlongedGraphicOrSadistic",
+                   "violenceRealistic",
++                  "ageRatingOverride",
+                   "koreaAgeRatingOverride"
+                 ]
+               }
+@@ -83719,6 +83726,7 @@
+                   "violenceCartoonOrFantasy",
+                   "violenceRealisticProlongedGraphicOrSadistic",
+                   "violenceRealistic",
++                  "ageRatingOverride",
+                   "koreaAgeRatingOverride"
+                 ]
+               }
+@@ -98135,6 +98143,7 @@
+                   "violenceCartoonOrFantasy",
+                   "violenceRealisticProlongedGraphicOrSadistic",
+                   "violenceRealistic",
++                  "ageRatingOverride",
+                   "koreaAgeRatingOverride"
+                 ]
+               }
+@@ -110716,6 +110725,7 @@
+                   "violenceCartoonOrFantasy",
+                   "violenceRealisticProlongedGraphicOrSadistic",
+                   "violenceRealistic",
++                  "ageRatingOverride",
+                   "koreaAgeRatingOverride"
+                 ]
+               }
+@@ -132774,6 +132784,7 @@
+                   "duration",
+                   "offerMode",
+                   "numberOfPeriods",
++                  "totalNumberOfCodes",
+                   "active",
+                   "subscription",
+                   "oneTimeUseCodes",
+@@ -133296,6 +133307,7 @@
+                   "duration",
+                   "offerMode",
+                   "numberOfPeriods",
++                  "totalNumberOfCodes",
+                   "active",
+                   "subscription",
+                   "oneTimeUseCodes",
+@@ -133548,6 +133560,7 @@
+                   "duration",
+                   "offerMode",
+                   "numberOfPeriods",
++                  "totalNumberOfCodes",
+                   "active",
+                   "subscription",
+                   "oneTimeUseCodes",
+@@ -135501,6 +135514,7 @@
+                   "duration",
+                   "offerMode",
+                   "numberOfPeriods",
++                  "totalNumberOfCodes",
+                   "active",
+                   "subscription",
+                   "oneTimeUseCodes",
+@@ -141826,6 +141840,14 @@
+                   "NONE"
+                 ]
+               },
++              "ageRatingOverride": {
++                "type": "string",
++                "enum": [
++                  "NONE",
++                  "SEVENTEEN_PLUS",
++                  "UNRATED"
++                ]
++              },
+               "koreaAgeRatingOverride": {
+                 "type": "string",
+                 "enum": [
+@@ -141972,6 +141994,14 @@
+                       "NONE"
+                     ]
+                   },
++                  "ageRatingOverride": {
++                    "type": "string",
++                    "enum": [
++                      "NONE",
++                      "SEVENTEEN_PLUS",
++                      "UNRATED"
++                    ]
++                  },
+                   "koreaAgeRatingOverride": {
+                     "type": "string",
+                     "enum": [
+@@ -184127,6 +184157,9 @@
+               "numberOfPeriods": {
+                 "type": "integer"
+               },
++              "totalNumberOfCodes": {
++                "type": "integer"
++              },
+               "active": {
+                 "type": "boolean"
+               }


### PR DESCRIPTION
We fixed a few regressions in the API spec when version 4.0.0 of the App Store Connect API dropped. We did not do the patches at the time.

While we fix another bug in the API (you can have empty deeplink APIs, which fail decoding to URLs), we also have added patches to make sure the v4.0.0 changes are respected on every update.