### PR TITLE
Fix decoding error in `MetricsInsight` model for `referenceVersions` field

### DIFF
--- a/Sources/OpenAPI/Generated/Entities/MetricsInsight.swift
+++ b/Sources/OpenAPI/Generated/Entities/MetricsInsight.swift
@@ -8,7 +8,7 @@ public struct MetricsInsight: Codable {
 	public var latestVersion: String?
 	public var metric: String?
 	public var summaryString: String?
-	public var referenceVersions: String?
+	public var referenceVersions: [String]?
 	public var maxLatestVersionValue: Double?
 	public var subSystemLabel: String?
 	public var isHighImpact: Bool?
@@ -52,7 +52,7 @@ public struct MetricsInsight: Codable {
 		}
 	}
 
-	public init(metricCategory: MetricCategory? = nil, latestVersion: String? = nil, metric: String? = nil, summaryString: String? = nil, referenceVersions: String? = nil, maxLatestVersionValue: Double? = nil, subSystemLabel: String? = nil, isHighImpact: Bool? = nil, populations: [Population]? = nil) {
+	public init(metricCategory: MetricCategory? = nil, latestVersion: String? = nil, metric: String? = nil, summaryString: String? = nil, referenceVersions: [String]? = nil, maxLatestVersionValue: Double? = nil, subSystemLabel: String? = nil, isHighImpact: Bool? = nil, populations: [Population]? = nil) {
 		self.metricCategory = metricCategory
 		self.latestVersion = latestVersion
 		self.metric = metric
@@ -70,7 +70,7 @@ public struct MetricsInsight: Codable {
 		self.latestVersion = try values.decodeIfPresent(String.self, forKey: "latestVersion")
 		self.metric = try values.decodeIfPresent(String.self, forKey: "metric")
 		self.summaryString = try values.decodeIfPresent(String.self, forKey: "summaryString")
-		self.referenceVersions = try values.decodeIfPresent(String.self, forKey: "referenceVersions")
+		self.referenceVersions = try values.decodeIfPresent([String].self, forKey: "referenceVersions")
 		self.maxLatestVersionValue = try values.decodeIfPresent(Double.self, forKey: "maxLatestVersionValue")
 		self.subSystemLabel = try values.decodeIfPresent(String.self, forKey: "subSystemLabel")
 		self.isHighImpact = try values.decodeIfPresent(Bool.self, forKey: "highImpact")

--- a/Sources/OpenAPI/Generated/Entities/XcodeMetrics.swift
+++ b/Sources/OpenAPI/Generated/Entities/XcodeMetrics.swift
@@ -127,7 +127,7 @@ public struct XcodeMetrics: Codable {
 						public var version: String?
 						public var value: Double?
 						public var errorMargin: Double?
-						public var percentageBreakdown: PercentageBreakdown?
+						public var percentageBreakdown: [PercentageBreakdown]?
 						public var goal: String?
 
 						public struct PercentageBreakdown: Codable {
@@ -152,7 +152,7 @@ public struct XcodeMetrics: Codable {
 							}
 						}
 
-						public init(version: String? = nil, value: Double? = nil, errorMargin: Double? = nil, percentageBreakdown: PercentageBreakdown? = nil, goal: String? = nil) {
+						public init(version: String? = nil, value: Double? = nil, errorMargin: Double? = nil, percentageBreakdown: [PercentageBreakdown]? = nil, goal: String? = nil) {
 							self.version = version
 							self.value = value
 							self.errorMargin = errorMargin
@@ -165,7 +165,7 @@ public struct XcodeMetrics: Codable {
 							self.version = try values.decodeIfPresent(String.self, forKey: "version")
 							self.value = try values.decodeIfPresent(Double.self, forKey: "value")
 							self.errorMargin = try values.decodeIfPresent(Double.self, forKey: "errorMargin")
-							self.percentageBreakdown = try values.decodeIfPresent(PercentageBreakdown.self, forKey: "percentageBreakdown")
+							self.percentageBreakdown = try values.decodeIfPresent([PercentageBreakdown].self, forKey: "percentageBreakdown")
 							self.goal = try values.decodeIfPresent(String.self, forKey: "goal")
 						}
 


### PR DESCRIPTION
### Summary

This PR fixes a decoding issue in the `MetricsInsight` model where the `referenceVersions` field was incorrectly expected to be a `String`, but the actual API response contained an array.

### Error Details

```swift
typeMismatch(Swift.String, Swift.DecodingError.Context(
codingPath: [
StringCodingKey(stringValue: "insights", intValue: nil),
StringCodingKey(stringValue: "regressions", intValue: nil),
_CodingKey(stringValue: "Index 0", intValue: 0),
StringCodingKey(stringValue: "referenceVersions", intValue: nil)
],
debugDescription: "Expected to decode String but found an array instead.",
underlyingError: nil
))
```

### Changes

- Updated the type of `referenceVersions` in `MetricsInsight` (or the corresponding nested model) from `String` to `[String]` to match the actual response format.


### Notes

- This change prevents decoding failures when processing regression insights that include a list of reference versions.