### PR TITLE
Fix decoding error in `XcodeMetrics` model for `percentageBreakdown` field

### DIFF
--- a/Sources/OpenAPI/Generated/Entities/XcodeMetrics.swift
+++ b/Sources/OpenAPI/Generated/Entities/XcodeMetrics.swift
@@ -127,7 +127,7 @@ public struct XcodeMetrics: Codable {
 						public var version: String?
 						public var value: Double?
 						public var errorMargin: Double?
-						public var percentageBreakdown: PercentageBreakdown?
+						public var percentageBreakdown: [PercentageBreakdown]?
 						public var goal: String?
 
 						public struct PercentageBreakdown: Codable {
@@ -152,7 +152,7 @@ public struct XcodeMetrics: Codable {
 							}
 						}
 
-						public init(version: String? = nil, value: Double? = nil, errorMargin: Double? = nil, percentageBreakdown: PercentageBreakdown? = nil, goal: String? = nil) {
+						public init(version: String? = nil, value: Double? = nil, errorMargin: Double? = nil, percentageBreakdown: [PercentageBreakdown]? = nil, goal: String? = nil) {
 							self.version = version
 							self.value = value
 							self.errorMargin = errorMargin
@@ -165,7 +165,7 @@ public struct XcodeMetrics: Codable {
 							self.version = try values.decodeIfPresent(String.self, forKey: "version")
 							self.value = try values.decodeIfPresent(Double.self, forKey: "value")
 							self.errorMargin = try values.decodeIfPresent(Double.self, forKey: "errorMargin")
-							self.percentageBreakdown = try values.decodeIfPresent(PercentageBreakdown.self, forKey: "percentageBreakdown")
+							self.percentageBreakdown = try values.decodeIfPresent([PercentageBreakdown].self, forKey: "percentageBreakdown")
 							self.goal = try values.decodeIfPresent(String.self, forKey: "goal")
 						}
 


### PR DESCRIPTION
**What**
- API expected type for percentageBreakdown update from single item to Array
- Fixing decoding error in Xcode metrics

`
Error: typeMismatch(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath: [
    StringCodingKey(stringValue: "productData", intValue: nil), _CodingKey(stringValue: "Index 0", intValue: 0), 
    StringCodingKey(stringValue: "metricCategories", intValue: nil), _CodingKey(stringValue: "Index 4", intValue: 4), 
    StringCodingKey(stringValue: "metrics", intValue: nil), _CodingKey(stringValue: "Index 0", intValue: 0), 
    StringCodingKey(stringValue: "datasets", intValue: nil), _CodingKey(stringValue: "Index 0", intValue: 0), 
    StringCodingKey(stringValue: "points", intValue: nil), _CodingKey(stringValue: "Index 0", intValue: 0), 
    StringCodingKey(stringValue: "percentageBreakdown", intValue: nil)
    ], 
    debugDescription: "Expected to decode Dictionary<String, Any> but found an array instead.", underlyingError: nil))
`