### PR TITLE
fix: date format fail

### DIFF
--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -213,6 +213,11 @@ public final class APIProvider {
             if let date = isoDateFormatter.date(from: dateStr) {
                 return date
             }
+            // Example: 2025-10-01T19:37:15-07:00 (without fractional seconds)
+            isoDateFormatter.formatOptions = [.withInternetDateTime]
+            if let date = isoDateFormatter.date(from: dateStr) {
+                return date
+            }
             throw APIProvider.Error.dateDecodingError(dateStr)
         })
         return decoder


### PR DESCRIPTION
When I use this API `APIEndpoint.v1.apps.id(appID).customerReviews`, it would fail with this `APIProvider.Error.dateDecodingError` error.

The date look like this: `"createdDate" : "2025-11-06T06:40:31-08:00"`