### PR TITLE
feat: replace swift-crypto dependency with native CryptoKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/CreateAPI/URLQueryEncoder.git", from: "0.2.0"),
+    .package(url: "https://github.com/apple/swift-crypto.git", from: "3.12.3"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.0"),
     .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.20"),
     .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.1.0"))
@@ -10,6 +11,7 @@ var dependencies: [Package.Dependency] = [
 
 var targetDependencies: [Target.Dependency] = [
     .product(name: "URLQueryEncoder", package: "URLQueryEncoder"),
+    .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux])),
 ]
 
 #if os(Linux)

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,6 @@ import PackageDescription
 
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/CreateAPI/URLQueryEncoder.git", from: "0.2.0"),
-    .package(url: "https://github.com/apple/swift-crypto.git", from: "3.12.3"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.0"),
     .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.20"),
     .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.1.0"))
@@ -11,7 +10,6 @@ var dependencies: [Package.Dependency] = [
 
 var targetDependencies: [Target.Dependency] = [
     .product(name: "URLQueryEncoder", package: "URLQueryEncoder"),
-    .product(name: "Crypto", package: "swift-crypto")
 ]
 
 #if os(Linux)

--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Crypto
+import CryptoKit
 
 /// The JWT Header contains information specific to the App Store Connect API Keys, such as algorithm and keys.
 private struct Header: Codable {

--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -6,7 +6,11 @@
 //
 
 import Foundation
+#if canImport(CryptoKit)
 import CryptoKit
+#elseif canImport(Crypto)
+import Crypto
+#endif
 
 /// The JWT Header contains information specific to the App Store Connect API Keys, such as algorithm and keys.
 private struct Header: Codable {

--- a/Tests/JWTRequestsAuthenticatorTests.swift
+++ b/Tests/JWTRequestsAuthenticatorTests.swift
@@ -7,7 +7,6 @@
 //
 
 import XCTest
-import Crypto
 @testable import AppStoreConnect_Swift_SDK
 import Foundation
 #if canImport(FoundationNetworking)


### PR DESCRIPTION
Closes #324

JWT.swift was the only file importing the `Crypto` package. All used APIs (`P256.Signing.PrivateKey`, `.signature(for:)`, `.rawRepresentation`) have direct equivalents in the native `CryptoKit` framework.

Changes:
- Replace `import Crypto` with `import CryptoKit` in `JWT.swift`
- Remove `swift-crypto` dependency from `Package.swift`

All 22 tests pass.