### PR TITLE
Add configurable base URL and JWT scope claim support

### DIFF
--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -32,6 +32,9 @@ public struct APIConfiguration {
     /// The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
     let expirationDuration: TimeInterval
 
+    /// Optional JWT scope claim for APIs that require restricted access (e.g. `["/notary/v2"]` for the Notary API).
+    let scope: [String]?
+
     /// The range of values allowed for the expiration duration of the token.
     private let allowedExpirationDurationRange: ClosedRange<TimeInterval> = 0...1200
 
@@ -42,9 +45,11 @@ public struct APIConfiguration {
     ///   - privateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
     ///   - privateKey: Your private key stripped out of the -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY----- lines.
     ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes. Defaults to 20 minutes.
-    public init(issuerID: String, privateKeyID: String, privateKey: String, expirationDuration: TimeInterval = 60 * 20) throws {
+    ///   - scope: Optional JWT scope claim for APIs that require restricted access (e.g. `["/notary/v2"]` for the Notary API).
+    public init(issuerID: String, privateKeyID: String, privateKey: String, expirationDuration: TimeInterval = 60 * 20, scope: [String]? = nil) throws {
         self.privateKeyID = privateKeyID
         self.issuerID = issuerID
+        self.scope = scope
         guard let base64Key = Data(base64Encoded: privateKey) else {
             throw JWT.Error.invalidBase64EncodedPrivateKey
         }
@@ -65,9 +70,11 @@ public struct APIConfiguration {
     ///   - individualPrivateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
     ///   - individualPrivateKey: The contents of the individual private key from App Store Connect
     ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes. Defaults to 20 minutes.
-    public init(individualPrivateKeyID: String, individualPrivateKey: String, expirationDuration: TimeInterval = 60 * 20) throws {
+    ///   - scope: Optional JWT scope claim for APIs that require restricted access.
+    public init(individualPrivateKeyID: String, individualPrivateKey: String, expirationDuration: TimeInterval = 60 * 20, scope: [String]? = nil) throws {
         self.privateKeyID = individualPrivateKeyID
         self.issuerID = nil
+        self.scope = scope
 
         guard let base64Key = Data(base64Encoded: individualPrivateKey) else {
             throw JWT.Error.invalidBase64EncodedPrivateKey
@@ -90,8 +97,10 @@ public struct APIConfiguration {
     ///   - privateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34). Will be inferred from `privateKeyURL` if nil.
     ///   - privateKeyURL: A file URL that references the path to your private key file.
     ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes. Defaults to 20 minutes.
-    public init(issuerID: String, privateKeyID: String? = nil, privateKeyURL: URL, expirationDuration: TimeInterval = 60 * 20) throws {
+    ///   - scope: Optional JWT scope claim for APIs that require restricted access.
+    public init(issuerID: String, privateKeyID: String? = nil, privateKeyURL: URL, expirationDuration: TimeInterval = 60 * 20, scope: [String]? = nil) throws {
         self.issuerID = issuerID
+        self.scope = scope
         if let privateKeyID = privateKeyID {
             self.privateKeyID = privateKeyID
         } else {
@@ -116,8 +125,10 @@ public struct APIConfiguration {
     ///   - individualPrivateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34). Will be inferred from `privateKeyURL` if nil.
     ///   - individualPrivateKeyURL: A file URL that references the path to your private key file.
     ///   - expirationDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes. Defaults to 20 minutes.
-    public init(individualPrivateKeyID: String? = nil, privateKeyURL: URL, expirationDuration: TimeInterval = 60 * 20) throws {
+    ///   - scope: Optional JWT scope claim for APIs that require restricted access.
+    public init(individualPrivateKeyID: String? = nil, privateKeyURL: URL, expirationDuration: TimeInterval = 60 * 20, scope: [String]? = nil) throws {
         self.issuerID = nil
+        self.scope = scope
         if let individualPrivateKeyID {
             self.privateKeyID = individualPrivateKeyID
         } else {

--- a/Sources/Endpoint.swift
+++ b/Sources/Endpoint.swift
@@ -25,39 +25,45 @@ struct AnyEncodable: Encodable {
 /// Credits to the https://github.com/kean/Get repository for this class.
 /// We've copied this over since it works nicely together with the CreateAPI OpenAPI generator.
 public struct Request<Response> {
+    /// The default App Store Connect API base URL.
+    public static var defaultBaseURL: URL {
+        guard let url = URL(string: "https://api.appstoreconnect.apple.com") else {
+            fatalError("Invalid App Store Connect API base URL")
+        }
+        return url
+    }
+
     public var method: String
     public var path: String
     public var query: [(String, String?)]?
     var body: AnyEncodable?
     public var headers: [String: String]?
     public var id: String?
+    public var baseURL: URL
 
-    public init(path: String, method: String, query: [(String, String?)]? = nil, headers: [String: String]? = nil, id: String) {
+    public init(path: String, method: String, query: [(String, String?)]? = nil, headers: [String: String]? = nil, id: String, baseURL: URL = Self.defaultBaseURL) {
         self.method = method
         self.path = path
         self.query = query
         self.headers = headers
         self.id = id
+        self.baseURL = baseURL
     }
 
-    public init<U: Encodable>(path: String, method: String, query: [(String, String?)]? = nil, body: U?, headers: [String: String]? = nil, id: String) {
+    public init<U: Encodable>(path: String, method: String, query: [(String, String?)]? = nil, body: U?, headers: [String: String]? = nil, id: String, baseURL: URL = Self.defaultBaseURL) {
         self.method = method
         self.path = path
         self.query = query
         self.body = body.map(AnyEncodable.init)
         self.headers = headers
         self.id = id
+        self.baseURL = baseURL
     }
 }
 
 // MARK: - URLRequestConvertible
 
 extension Request {
-
-    internal var baseURL: URL {
-        // swiftlint:disable:next force_unwrapping
-        return URL(string: "https://api.appstoreconnect.apple.com")!
-    }
 
     private func makeURL(path: String, query: [(String, String?)]?) throws -> URL {
         let url = baseURL.appendingPathComponent(path)

--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -35,19 +35,23 @@ private struct TeamPayload: Codable {
         case expirationTime = "exp"
         case audience = "aud"
         case issuedAtTime = "iat"
+        case scope
     }
 
     /// Your issuer identifier from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
     let issuerIdentifier: String
 
-    /// The token's expiration time, in Unix epoch time; tokens that expire more than 20 minutes in the future are not valid (Ex: 1528408800)
+    /// The token’s expiration time, in Unix epoch time; tokens that expire more than 20 minutes in the future are not valid (Ex: 1528408800)
     let expirationTime: TimeInterval
-    
+
     /// The token’s creation time, in UNIX epoch time (Ex: 1528407600)
     let issuedAtTime: TimeInterval
 
     /// The required audience which is set to the App Store Connect version.
     let audience: String = "appstoreconnect-v1"
+
+    /// Optional scope claim for APIs that require restricted access (e.g. `["/notary/v2"]`).
+    let scope: [String]?
 }
 
 private struct IndividualPayload: Codable {
@@ -57,19 +61,23 @@ private struct IndividualPayload: Codable {
         case expirationTime = "exp"
         case audience = "aud"
         case issuedAtTime = "iat"
+        case scope
     }
 
     /// The subject to pass to the payload when using individual keys
     let subject: String = "user"
 
-    /// The token's expiration time, in Unix epoch time; tokens that expire more than 20 minutes in the future are not valid (Ex: 1528408800)
+    /// The token’s expiration time, in Unix epoch time; tokens that expire more than 20 minutes in the future are not valid (Ex: 1528408800)
     let expirationTime: TimeInterval
-    
+
     /// The token’s creation time, in UNIX epoch time (Ex: 1528407600)
     let issuedAtTime: TimeInterval
 
     /// The required audience which is set to the App Store Connect version.
     let audience: String = "appstoreconnect-v1"
+
+    /// Optional scope claim for APIs that require restricted access (e.g. `["/notary/v2"]`).
+    let scope: [String]?
 }
 
 protocol JWTCreatable {
@@ -116,16 +124,21 @@ public struct JWT: Codable, JWTCreatable {
     /// The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
     private let expireDuration: TimeInterval
 
+    /// Optional scope claim for APIs that require restricted access (e.g. the Notary API uses `["/notary/v2"]`).
+    private let scope: [String]?
+
     /// Creates a new JWT Factory to create signed requests for the App Store Connect API.
     ///
     /// - Parameters:
     ///   - keyIdentifier: Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
     ///   - issuerIdentifier: Your issuer identifier from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
     ///   - expireDuration: The token's expiration duration in seconds. Tokens that expire more than 20 minutes in the future are not valid, so set it to a max of 20 minutes.
-    public init(keyIdentifier: String, issuerIdentifier: String?, expireDuration: TimeInterval) {
+    ///   - scope: Optional scope claim for APIs that require restricted access. For example, the Notary API requires `["/notary/v2"]`.
+    public init(keyIdentifier: String, issuerIdentifier: String?, expireDuration: TimeInterval, scope: [String]? = nil) {
         header = Header(keyIdentifier: keyIdentifier)
         self.issuerIdentifier = issuerIdentifier
         self.expireDuration = expireDuration
+        self.scope = scope
     }
 
     /// Combine the header and the payload as a digest for signing.
@@ -137,12 +150,14 @@ public struct JWT: Codable, JWTCreatable {
             payload = TeamPayload(
                 issuerIdentifier: issuerIdentifier,
                 expirationTime: expirationTime,
-                issuedAtTime: now.timeIntervalSince1970
+                issuedAtTime: now.timeIntervalSince1970,
+                scope: scope
             )
         } else {
             payload = IndividualPayload(
                 expirationTime: expirationTime,
-                issuedAtTime: now.timeIntervalSince1970
+                issuedAtTime: now.timeIntervalSince1970,
+                scope: scope
             )
         }
         

--- a/Sources/JWT/JWTRequestsAuthenticator.swift
+++ b/Sources/JWT/JWTRequestsAuthenticator.swift
@@ -22,7 +22,7 @@ final class JWTRequestsAuthenticator {
 
     init(apiConfiguration: APIConfiguration) {
         self.apiConfiguration = apiConfiguration
-        self.jwtCreator = JWT(keyIdentifier: apiConfiguration.privateKeyID, issuerIdentifier: apiConfiguration.issuerID, expireDuration: apiConfiguration.expirationDuration)
+        self.jwtCreator = JWT(keyIdentifier: apiConfiguration.privateKeyID, issuerIdentifier: apiConfiguration.issuerID, expireDuration: apiConfiguration.expirationDuration, scope: apiConfiguration.scope)
     }
 
     /// Generates a new JWT Token, but only if the in memory cached one is not expired.


### PR DESCRIPTION
## Motivation

The App Store Connect API base URL is currently hardcoded in `Request<Response>`, preventing use of the SDK's authentication and request infrastructure with related Apple APIs that share the same JWT-based auth but live at different base URLs.

The primary use case is the [Apple Notary API v2](https://developer.apple.com/documentation/notaryapi), which lives at `appstoreconnect.apple.com/notary/v2/` (vs `api.appstoreconnect.apple.com`) and requires a `scope` claim in the JWT payload. Today, anyone wanting to use the Notary API alongside the ASC API must build an entirely separate JWT + HTTP client despite sharing the same credentials.

## Changes

### `Request<Response>` — configurable `baseURL`
- Promotes `baseURL` from a hardcoded internal computed property to a **public stored property** with a default of the standard ASC API URL
- Adds a `defaultBaseURL` static computed property for reference
- **Fully backward compatible** — all existing code compiles without changes since the new `baseURL` parameter defaults to the current value

### `JWT` — optional `scope` claim
- Adds an optional `scope: [String]?` parameter to `JWT.init` (defaults to `nil`)
- When `nil`, the claim is omitted entirely from the encoded payload (standard `Codable` behavior for optionals)
- When set (e.g. `["/notary/v2"]`), it's included in the JWT payload as required by Apple's Notary API [authentication docs](https://developer.apple.com/documentation/notaryapi/submitting-software-for-notarization-over-the-web)

## Usage

```swift
// Existing usage — no changes required
let request = APIEndpoint.v1.apps.get()
let response = try await provider.request(request)

// New: request with custom base URL
var request = APIEndpoint.v1.someEndpoint.get()
request.baseURL = URL(string: "https://appstoreconnect.apple.com")!

// New: JWT with scope for Notary API
let jwt = JWT(keyIdentifier: "KEY_ID", issuerIdentifier: "ISSUER_ID", expireDuration: 600, scope: ["/notary/v2"])
```

## Testing

- All 22 existing tests pass
- No changes to generated OpenAPI code
- No breaking API changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)